### PR TITLE
Fix type error in search bar filter chips

### DIFF
--- a/components/search/filter-chip.tsx
+++ b/components/search/filter-chip.tsx
@@ -13,7 +13,7 @@ export interface FilterChipProps {
   label: string;
 
   /** Filter type for styling */
-  type?: 'status' | 'date' | 'category' | 'numeric' | 'default';
+  type?: 'status' | 'date' | 'category' | 'numeric' | 'text' | 'default';
 
   /** Callback when filter is removed */
   onRemove: () => void;
@@ -24,6 +24,7 @@ const chipVariants = {
   date: 'secondary' as const,
   category: 'outline' as const,
   numeric: 'outline' as const,
+  text: 'secondary' as const,
   default: 'secondary' as const,
 };
 


### PR DESCRIPTION
Add 'text' as a valid filter type to FilterChip component to match the ActiveFilter type definition. This resolves the TypeScript error where filter.type could be 'text' but FilterChip only accepted 'default' instead.