### PR TITLE
Add ID search functionality to search bars

### DIFF
--- a/lib/filters/filter-configs.ts
+++ b/lib/filters/filter-configs.ts
@@ -47,7 +47,7 @@ export interface EntityFilterConfig {
 // ============================================================================
 
 export const customersFilterConfig: EntityFilterConfig = {
-  searchFields: ['firstname', 'lastname', 'email', 'phone'],
+  searchFields: ['firstname', 'lastname', 'email', 'phone', 'iid'],
 
   dateFilters: [
     {
@@ -150,7 +150,7 @@ export const itemsFilterConfig: EntityFilterConfig = {
 // ============================================================================
 
 export const rentalsFilterConfig: EntityFilterConfig = {
-  searchFields: ['customer.firstname', 'customer.lastname'],
+  searchFields: ['customer.firstname', 'customer.lastname', 'customer.iid'],
 
   statusFilters: [
     {
@@ -207,7 +207,7 @@ export const rentalsFilterConfig: EntityFilterConfig = {
 // ============================================================================
 
 export const reservationsFilterConfig: EntityFilterConfig = {
-  searchFields: ['customer_name', 'customer_phone'],
+  searchFields: ['customer_name', 'customer_phone', 'customer_iid'],
 
   statusFilters: [
     {


### PR DESCRIPTION
- Add 'iid' to searchFields for customers, rentals, and reservations
- Implement smart numeric search that strips leading zeros
- When searching purely numeric values (e.g., "5", "005", "0005"):
  * Strip leading zeros and match iid fields by numeric value
  * Still search text fields for the original term
- Non-numeric searches continue to use text search as before

This allows users to search for items/customers by ID with or without leading zeros (e.g., searching "5" will match iid 5, as will "0005").