### PR TITLE
Create detail view for entry information

### DIFF
--- a/components/detail-sheets/customer-detail-sheet.tsx
+++ b/components/detail-sheets/customer-detail-sheet.tsx
@@ -1,0 +1,656 @@
+/**
+ * Customer Detail Sheet Component
+ * Displays and edits customer information with rental/reservation history
+ */
+
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { PencilIcon, SaveIcon, XIcon } from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetFooter,
+} from '@/components/ui/sheet';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { collections } from '@/lib/pocketbase/client';
+import { formatDate, formatCurrency, calculateRentalStatus } from '@/lib/utils/formatting';
+import type { Customer, CustomerFormData, Rental, RentalExpanded, Reservation, ReservationExpanded, HighlightColor } from '@/types';
+
+// Validation schema
+const customerSchema = z.object({
+  firstname: z.string().min(1, 'Vorname ist erforderlich'),
+  lastname: z.string().min(1, 'Nachname ist erforderlich'),
+  email: z.string().email('Ungültige E-Mail-Adresse').optional().or(z.literal('')),
+  phone: z.string().optional(),
+  street: z.string().optional(),
+  postal_code: z.string().optional(),
+  city: z.string().optional(),
+  registered_on: z.string(),
+  renewed_on: z.string().optional(),
+  heard: z.string().optional(),
+  newsletter: z.boolean(),
+  remark: z.string().optional(),
+  highlight_color: z.enum(['green', 'blue', 'yellow', 'red', '']).optional(),
+});
+
+type CustomerFormValues = z.infer<typeof customerSchema>;
+
+interface CustomerDetailSheetProps {
+  customer: Customer | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave?: (customer: Customer) => void;
+}
+
+export function CustomerDetailSheet({
+  customer,
+  open,
+  onOpenChange,
+  onSave,
+}: CustomerDetailSheetProps) {
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [rentals, setRentals] = useState<RentalExpanded[]>([]);
+  const [reservations, setReservations] = useState<ReservationExpanded[]>([]);
+  const [isLoadingHistory, setIsLoadingHistory] = useState(false);
+
+  const isNewCustomer = !customer?.id;
+
+  const form = useForm<CustomerFormValues>({
+    resolver: zodResolver(customerSchema),
+    defaultValues: {
+      firstname: '',
+      lastname: '',
+      email: '',
+      phone: '',
+      street: '',
+      postal_code: '',
+      city: '',
+      registered_on: new Date().toISOString().split('T')[0],
+      renewed_on: '',
+      heard: '',
+      newsletter: false,
+      remark: '',
+      highlight_color: '',
+    },
+  });
+
+  const { formState: { isDirty } } = form;
+
+  // Load customer data when customer changes
+  useEffect(() => {
+    if (customer) {
+      form.reset({
+        firstname: customer.firstname,
+        lastname: customer.lastname,
+        email: customer.email || '',
+        phone: customer.phone || '',
+        street: customer.street || '',
+        postal_code: customer.postal_code || '',
+        city: customer.city || '',
+        registered_on: customer.registered_on.split('T')[0],
+        renewed_on: customer.renewed_on?.split('T')[0] || '',
+        heard: customer.heard || '',
+        newsletter: customer.newsletter,
+        remark: customer.remark || '',
+        highlight_color: (customer.highlight_color as string) || '',
+      });
+      setIsEditMode(false);
+    } else if (isNewCustomer) {
+      form.reset({
+        firstname: '',
+        lastname: '',
+        email: '',
+        phone: '',
+        street: '',
+        postal_code: '',
+        city: '',
+        registered_on: new Date().toISOString().split('T')[0],
+        renewed_on: '',
+        heard: '',
+        newsletter: false,
+        remark: '',
+        highlight_color: '',
+      });
+      setIsEditMode(true);
+    }
+  }, [customer, isNewCustomer, form]);
+
+  // Load rental and reservation history
+  useEffect(() => {
+    if (customer?.id && open) {
+      loadHistory();
+    }
+  }, [customer?.id, open]);
+
+  const loadHistory = async () => {
+    if (!customer?.id) return;
+
+    setIsLoadingHistory(true);
+    try {
+      // Load rentals
+      const rentalsResult = await collections.rentals().getList<RentalExpanded>(1, 50, {
+        filter: `customer="${customer.id}"`,
+        sort: '-rented_on',
+        expand: 'customer,items',
+      });
+      setRentals(rentalsResult.items);
+
+      // Load reservations
+      const reservationsResult = await collections.reservations().getList<ReservationExpanded>(1, 50, {
+        filter: `customer_iid=${customer.iid}`,
+        sort: '-pickup',
+        expand: 'items',
+      });
+      setReservations(reservationsResult.items);
+    } catch (err) {
+      console.error('Error loading history:', err);
+    } finally {
+      setIsLoadingHistory(false);
+    }
+  };
+
+  const handleSave = async (data: CustomerFormValues) => {
+    setIsLoading(true);
+    try {
+      const formData: Partial<Customer> = {
+        firstname: data.firstname,
+        lastname: data.lastname,
+        email: data.email || undefined,
+        phone: data.phone || undefined,
+        street: data.street || undefined,
+        postal_code: data.postal_code || undefined,
+        city: data.city || undefined,
+        registered_on: data.registered_on,
+        renewed_on: data.renewed_on || undefined,
+        heard: data.heard || undefined,
+        newsletter: data.newsletter,
+        remark: data.remark || undefined,
+        highlight_color: (data.highlight_color as HighlightColor) || undefined,
+      };
+
+      let savedCustomer: Customer;
+      if (isNewCustomer) {
+        savedCustomer = await collections.customers().create<Customer>(formData);
+        toast.success('Kunde erfolgreich erstellt');
+      } else if (customer) {
+        savedCustomer = await collections.customers().update<Customer>(customer.id, formData);
+        toast.success('Kunde erfolgreich aktualisiert');
+      } else {
+        return;
+      }
+
+      onSave?.(savedCustomer);
+      setIsEditMode(false);
+      onOpenChange(false);
+    } catch (err) {
+      console.error('Error saving customer:', err);
+      toast.error('Fehler beim Speichern des Kunden');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    if (isDirty) {
+      setShowCancelDialog(true);
+    } else {
+      if (isNewCustomer) {
+        onOpenChange(false);
+      } else {
+        setIsEditMode(false);
+      }
+    }
+  };
+
+  const handleConfirmCancel = () => {
+    setShowCancelDialog(false);
+    if (isNewCustomer) {
+      onOpenChange(false);
+    } else {
+      form.reset();
+      setIsEditMode(false);
+    }
+  };
+
+  const getHighlightColorBadge = (color?: HighlightColor) => {
+    if (!color) return null;
+    const colorMap = {
+      green: 'bg-green-500',
+      blue: 'bg-blue-500',
+      yellow: 'bg-yellow-500',
+      red: 'bg-red-500',
+    };
+    return (
+      <Badge className={`${colorMap[color]} text-white`}>
+        {color}
+      </Badge>
+    );
+  };
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={(open) => {
+        if (!open && isDirty) {
+          setShowCancelDialog(true);
+        } else {
+          onOpenChange(open);
+        }
+      }}>
+        <SheetContent className="w-full sm:max-w-4xl overflow-y-auto">
+          <SheetHeader className="border-b pb-4">
+            <div className="flex items-center justify-between">
+              <SheetTitle>
+                {isNewCustomer ? 'Neuer Kunde' : `Kunde #${String(customer?.iid).padStart(4, '0')}`}
+              </SheetTitle>
+              {!isNewCustomer && !isEditMode && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setIsEditMode(true)}
+                >
+                  <PencilIcon className="size-4 mr-2" />
+                  Bearbeiten
+                </Button>
+              )}
+            </div>
+          </SheetHeader>
+
+          <form onSubmit={form.handleSubmit(handleSave)} className="space-y-6 py-6">
+            {/* Basic Information */}
+            <section>
+              <h3 className="font-semibold text-lg mb-4">Basisdaten</h3>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="firstname">Vorname *</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="firstname"
+                      {...form.register('firstname')}
+                      className="mt-1"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm">{customer?.firstname || '—'}</p>
+                  )}
+                  {form.formState.errors.firstname && (
+                    <p className="text-sm text-destructive mt-1">
+                      {form.formState.errors.firstname.message}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="lastname">Nachname *</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="lastname"
+                      {...form.register('lastname')}
+                      className="mt-1"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm">{customer?.lastname || '—'}</p>
+                  )}
+                  {form.formState.errors.lastname && (
+                    <p className="text-sm text-destructive mt-1">
+                      {form.formState.errors.lastname.message}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="email">E-Mail</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="email"
+                      type="email"
+                      {...form.register('email')}
+                      className="mt-1"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm">{customer?.email || '—'}</p>
+                  )}
+                  {form.formState.errors.email && (
+                    <p className="text-sm text-destructive mt-1">
+                      {form.formState.errors.email.message}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="phone">Telefon</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="phone"
+                      {...form.register('phone')}
+                      className="mt-1"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm">{customer?.phone || '—'}</p>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            {/* Address */}
+            <section>
+              <h3 className="font-semibold text-lg mb-4">Adresse</h3>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="col-span-2">
+                  <Label htmlFor="street">Straße</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="street"
+                      {...form.register('street')}
+                      className="mt-1"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm">{customer?.street || '—'}</p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="postal_code">PLZ</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="postal_code"
+                      {...form.register('postal_code')}
+                      className="mt-1"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm">{customer?.postal_code || '—'}</p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="city">Stadt</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="city"
+                      {...form.register('city')}
+                      className="mt-1"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm">{customer?.city || '—'}</p>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            {/* Registration Details */}
+            <section>
+              <h3 className="font-semibold text-lg mb-4">Registrierung</h3>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="registered_on">Registriert am</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="registered_on"
+                      type="date"
+                      {...form.register('registered_on')}
+                      className="mt-1"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm">
+                      {customer ? formatDate(customer.registered_on) : '—'}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="renewed_on">Verlängert am</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="renewed_on"
+                      type="date"
+                      {...form.register('renewed_on')}
+                      className="mt-1"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm">
+                      {customer?.renewed_on ? formatDate(customer.renewed_on) : '—'}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="heard">Gehört über</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="heard"
+                      {...form.register('heard')}
+                      className="mt-1"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm">{customer?.heard || '—'}</p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="newsletter">Newsletter</Label>
+                  {isEditMode ? (
+                    <div className="flex items-center mt-1">
+                      <input
+                        id="newsletter"
+                        type="checkbox"
+                        {...form.register('newsletter')}
+                        className="mr-2"
+                      />
+                      <span className="text-sm">Abonniert</span>
+                    </div>
+                  ) : (
+                    <p className="mt-1 text-sm">
+                      {customer?.newsletter ? 'Ja' : 'Nein'}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            {/* Additional Information */}
+            <section>
+              <h3 className="font-semibold text-lg mb-4">Zusätzliche Informationen</h3>
+              <div className="space-y-4">
+                <div>
+                  <Label htmlFor="highlight_color">Markierungsfarbe</Label>
+                  {isEditMode ? (
+                    <select
+                      id="highlight_color"
+                      {...form.register('highlight_color')}
+                      className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    >
+                      <option value="">Keine</option>
+                      <option value="green">Grün</option>
+                      <option value="blue">Blau</option>
+                      <option value="yellow">Gelb</option>
+                      <option value="red">Rot</option>
+                    </select>
+                  ) : (
+                    <div className="mt-1">
+                      {getHighlightColorBadge(customer?.highlight_color) || <span className="text-sm">—</span>}
+                    </div>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="remark">Bemerkung</Label>
+                  {isEditMode ? (
+                    <Textarea
+                      id="remark"
+                      {...form.register('remark')}
+                      className="mt-1"
+                      rows={3}
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm whitespace-pre-wrap">
+                      {customer?.remark || '—'}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            {/* Rental History */}
+            {!isNewCustomer && (
+              <section>
+                <h3 className="font-semibold text-lg mb-4">Leihverlauf</h3>
+                {isLoadingHistory ? (
+                  <div className="flex justify-center py-4">
+                    <div className="h-6 w-6 animate-spin border-4 border-primary border-t-transparent rounded-full" />
+                  </div>
+                ) : rentals.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">Keine Leihvorgänge</p>
+                ) : (
+                  <div className="border rounded-md overflow-hidden">
+                    <table className="w-full text-sm">
+                      <thead className="bg-muted">
+                        <tr>
+                          <th className="px-3 py-2 text-left">Ausgeliehen</th>
+                          <th className="px-3 py-2 text-left">Erwartet</th>
+                          <th className="px-3 py-2 text-left">Zurückgegeben</th>
+                          <th className="px-3 py-2 text-left">Artikel</th>
+                          <th className="px-3 py-2 text-left">Status</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {rentals.map((rental) => {
+                          const status = calculateRentalStatus(
+                            rental.rented_on,
+                            rental.returned_on,
+                            rental.expected_on,
+                            rental.extended_on
+                          );
+                          return (
+                            <tr key={rental.id} className="border-t">
+                              <td className="px-3 py-2">{formatDate(rental.rented_on)}</td>
+                              <td className="px-3 py-2">{formatDate(rental.expected_on)}</td>
+                              <td className="px-3 py-2">
+                                {rental.returned_on ? formatDate(rental.returned_on) : '—'}
+                              </td>
+                              <td className="px-3 py-2">
+                                {rental.expand?.items?.length || 0} Artikel
+                              </td>
+                              <td className="px-3 py-2">
+                                <Badge variant={status === 'overdue' ? 'destructive' : 'secondary'}>
+                                  {status}
+                                </Badge>
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </section>
+            )}
+
+            {/* Reservation History */}
+            {!isNewCustomer && (
+              <section>
+                <h3 className="font-semibold text-lg mb-4">Reservierungen</h3>
+                {isLoadingHistory ? (
+                  <div className="flex justify-center py-4">
+                    <div className="h-6 w-6 animate-spin border-4 border-primary border-t-transparent rounded-full" />
+                  </div>
+                ) : reservations.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">Keine Reservierungen</p>
+                ) : (
+                  <div className="border rounded-md overflow-hidden">
+                    <table className="w-full text-sm">
+                      <thead className="bg-muted">
+                        <tr>
+                          <th className="px-3 py-2 text-left">Abholung</th>
+                          <th className="px-3 py-2 text-left">Artikel</th>
+                          <th className="px-3 py-2 text-left">Status</th>
+                          <th className="px-3 py-2 text-left">Kommentar</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {reservations.map((reservation) => (
+                          <tr key={reservation.id} className="border-t">
+                            <td className="px-3 py-2">{formatDate(reservation.pickup)}</td>
+                            <td className="px-3 py-2">
+                              {reservation.expand?.items?.length || 0} Artikel
+                            </td>
+                            <td className="px-3 py-2">
+                              <Badge variant={reservation.done ? 'secondary' : 'default'}>
+                                {reservation.done ? 'Erledigt' : 'Offen'}
+                              </Badge>
+                            </td>
+                            <td className="px-3 py-2">{reservation.comments || '—'}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </section>
+            )}
+          </form>
+
+          {isEditMode && (
+            <SheetFooter className="border-t pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleCancel}
+                disabled={isLoading}
+              >
+                <XIcon className="size-4 mr-2" />
+                Abbrechen
+              </Button>
+              <Button
+                type="submit"
+                onClick={form.handleSubmit(handleSave)}
+                disabled={isLoading}
+              >
+                <SaveIcon className="size-4 mr-2" />
+                {isLoading ? 'Speichern...' : 'Speichern'}
+              </Button>
+            </SheetFooter>
+          )}
+        </SheetContent>
+      </Sheet>
+
+      {/* Cancel Confirmation Dialog */}
+      <Dialog open={showCancelDialog} onOpenChange={setShowCancelDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Änderungen verwerfen?</DialogTitle>
+            <DialogDescription>
+              Sie haben ungespeicherte Änderungen. Möchten Sie diese wirklich verwerfen?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowCancelDialog(false)}>
+              Zurück
+            </Button>
+            <Button variant="destructive" onClick={handleConfirmCancel}>
+              Verwerfen
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/detail-sheets/index.ts
+++ b/components/detail-sheets/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Detail sheet components
+ * Export all detail sheets for easier importing
+ */
+
+export { CustomerDetailSheet } from './customer-detail-sheet';
+export { ItemDetailSheet } from './item-detail-sheet';
+export { RentalDetailSheet } from './rental-detail-sheet';
+export { ReservationDetailSheet } from './reservation-detail-sheet';

--- a/components/detail-sheets/item-detail-sheet.tsx
+++ b/components/detail-sheets/item-detail-sheet.tsx
@@ -1,0 +1,700 @@
+/**
+ * Item Detail Sheet Component
+ * Displays and edits item information with rental history
+ */
+
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { PencilIcon, SaveIcon, XIcon } from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetFooter,
+} from '@/components/ui/sheet';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { collections } from '@/lib/pocketbase/client';
+import { formatDate, formatCurrency, calculateRentalStatus } from '@/lib/utils/formatting';
+import type { Item, ItemFormData, RentalExpanded, ItemCategory, ItemStatus, HighlightColor } from '@/types';
+
+// Validation schema
+const itemSchema = z.object({
+  name: z.string().min(1, 'Name ist erforderlich'),
+  brand: z.string().optional(),
+  model: z.string().optional(),
+  description: z.string().optional(),
+  category: z.array(z.enum(['kitchen', 'household', 'garden', 'kids', 'leisure', 'diy', 'other'])),
+  deposit: z.number().min(0, 'Kaution muss positiv sein'),
+  synonyms: z.string().optional(), // Comma-separated
+  packaging: z.string().optional(),
+  manual: z.string().optional(),
+  parts: z.string().optional(),
+  copies: z.number().int().min(1, 'Anzahl muss mindestens 1 sein'),
+  status: z.enum(['instock', 'outofstock', 'reserved', 'onbackorder', 'lost', 'repairing', 'forsale', 'deleted']),
+  highlight_color: z.enum(['green', 'blue', 'yellow', 'red', '']).optional(),
+  internal_note: z.string().optional(),
+  added_on: z.string(),
+});
+
+type ItemFormValues = z.infer<typeof itemSchema>;
+
+interface ItemDetailSheetProps {
+  item: Item | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave?: (item: Item) => void;
+}
+
+export function ItemDetailSheet({
+  item,
+  open,
+  onOpenChange,
+  onSave,
+}: ItemDetailSheetProps) {
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [rentals, setRentals] = useState<RentalExpanded[]>([]);
+  const [isLoadingHistory, setIsLoadingHistory] = useState(false);
+
+  const isNewItem = !item?.id;
+
+  const form = useForm<ItemFormValues>({
+    resolver: zodResolver(itemSchema),
+    defaultValues: {
+      name: '',
+      brand: '',
+      model: '',
+      description: '',
+      category: [],
+      deposit: 0,
+      synonyms: '',
+      packaging: '',
+      manual: '',
+      parts: '',
+      copies: 1,
+      status: 'instock',
+      highlight_color: '',
+      internal_note: '',
+      added_on: new Date().toISOString().split('T')[0],
+    },
+  });
+
+  const { formState: { isDirty } } = form;
+
+  // Load item data when item changes
+  useEffect(() => {
+    if (item) {
+      form.reset({
+        name: item.name,
+        brand: item.brand || '',
+        model: item.model || '',
+        description: item.description || '',
+        category: item.category as ItemCategory[],
+        deposit: item.deposit,
+        synonyms: item.synonyms?.join(', ') || '',
+        packaging: item.packaging || '',
+        manual: item.manual || '',
+        parts: item.parts || '',
+        copies: item.copies,
+        status: item.status,
+        highlight_color: (item.highlight_color as string) || '',
+        internal_note: item.internal_note || '',
+        added_on: item.added_on.split('T')[0],
+      });
+      setIsEditMode(false);
+    } else if (isNewItem) {
+      form.reset({
+        name: '',
+        brand: '',
+        model: '',
+        description: '',
+        category: [],
+        deposit: 0,
+        synonyms: '',
+        packaging: '',
+        manual: '',
+        parts: '',
+        copies: 1,
+        status: 'instock',
+        highlight_color: '',
+        internal_note: '',
+        added_on: new Date().toISOString().split('T')[0],
+      });
+      setIsEditMode(true);
+    }
+  }, [item, isNewItem, form]);
+
+  // Load rental history
+  useEffect(() => {
+    if (item?.id && open) {
+      loadHistory();
+    }
+  }, [item?.id, open]);
+
+  const loadHistory = async () => {
+    if (!item?.id) return;
+
+    setIsLoadingHistory(true);
+    try {
+      // Load rentals that include this item
+      const rentalsResult = await collections.rentals().getList<RentalExpanded>(1, 50, {
+        filter: `items~"${item.id}"`,
+        sort: '-rented_on',
+        expand: 'customer,items',
+      });
+      setRentals(rentalsResult.items);
+    } catch (err) {
+      console.error('Error loading history:', err);
+    } finally {
+      setIsLoadingHistory(false);
+    }
+  };
+
+  const handleSave = async (data: ItemFormValues) => {
+    setIsLoading(true);
+    try {
+      const formData: Partial<Item> = {
+        name: data.name,
+        brand: data.brand || undefined,
+        model: data.model || undefined,
+        description: data.description || undefined,
+        category: data.category,
+        deposit: data.deposit,
+        synonyms: data.synonyms ? data.synonyms.split(',').map(s => s.trim()).filter(Boolean) : [],
+        packaging: data.packaging || undefined,
+        manual: data.manual || undefined,
+        parts: data.parts || undefined,
+        copies: data.copies,
+        status: data.status,
+        highlight_color: (data.highlight_color as HighlightColor) || undefined,
+        internal_note: data.internal_note || undefined,
+        added_on: data.added_on,
+      };
+
+      let savedItem: Item;
+      if (isNewItem) {
+        savedItem = await collections.items().create<Item>(formData);
+        toast.success('Artikel erfolgreich erstellt');
+      } else if (item) {
+        savedItem = await collections.items().update<Item>(item.id, formData);
+        toast.success('Artikel erfolgreich aktualisiert');
+      } else {
+        return;
+      }
+
+      onSave?.(savedItem);
+      setIsEditMode(false);
+      onOpenChange(false);
+    } catch (err) {
+      console.error('Error saving item:', err);
+      toast.error('Fehler beim Speichern des Artikels');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    if (isDirty) {
+      setShowCancelDialog(true);
+    } else {
+      if (isNewItem) {
+        onOpenChange(false);
+      } else {
+        setIsEditMode(false);
+      }
+    }
+  };
+
+  const handleConfirmCancel = () => {
+    setShowCancelDialog(false);
+    if (isNewItem) {
+      onOpenChange(false);
+    } else {
+      form.reset();
+      setIsEditMode(false);
+    }
+  };
+
+  const getHighlightColorBadge = (color?: HighlightColor) => {
+    if (!color) return null;
+    const colorMap = {
+      green: 'bg-green-500',
+      blue: 'bg-blue-500',
+      yellow: 'bg-yellow-500',
+      red: 'bg-red-500',
+    };
+    return (
+      <Badge className={`${colorMap[color]} text-white`}>
+        {color}
+      </Badge>
+    );
+  };
+
+  const getStatusBadge = (status: ItemStatus) => {
+    const statusMap = {
+      instock: { label: 'Auf Lager', variant: 'default' as const },
+      outofstock: { label: 'Ausgeliehen', variant: 'secondary' as const },
+      reserved: { label: 'Reserviert', variant: 'secondary' as const },
+      onbackorder: { label: 'Nachbestellt', variant: 'secondary' as const },
+      lost: { label: 'Verloren', variant: 'destructive' as const },
+      repairing: { label: 'Reparatur', variant: 'secondary' as const },
+      forsale: { label: 'Zu verkaufen', variant: 'secondary' as const },
+      deleted: { label: 'Gelöscht', variant: 'destructive' as const },
+    };
+    const { label, variant } = statusMap[status];
+    return <Badge variant={variant}>{label}</Badge>;
+  };
+
+  const categoryLabels = {
+    kitchen: 'Küche',
+    household: 'Haushalt',
+    garden: 'Garten',
+    kids: 'Kinder',
+    leisure: 'Freizeit',
+    diy: 'Heimwerken',
+    other: 'Sonstiges',
+  };
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={(open) => {
+        if (!open && isDirty) {
+          setShowCancelDialog(true);
+        } else {
+          onOpenChange(open);
+        }
+      }}>
+        <SheetContent className="w-full sm:max-w-4xl overflow-y-auto">
+          <SheetHeader className="border-b pb-4">
+            <div className="flex items-center justify-between">
+              <SheetTitle>
+                {isNewItem ? 'Neuer Artikel' : `Artikel #${String(item?.iid).padStart(4, '0')}`}
+              </SheetTitle>
+              {!isNewItem && !isEditMode && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setIsEditMode(true)}
+                >
+                  <PencilIcon className="size-4 mr-2" />
+                  Bearbeiten
+                </Button>
+              )}
+            </div>
+          </SheetHeader>
+
+          <form onSubmit={form.handleSubmit(handleSave)} className="space-y-6 py-6">
+            {/* Basic Information */}
+            <section>
+              <h3 className="font-semibold text-lg mb-4">Basisdaten</h3>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="col-span-2">
+                  <Label htmlFor="name">Name *</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="name"
+                      {...form.register('name')}
+                      className="mt-1"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm font-medium">{item?.name || '—'}</p>
+                  )}
+                  {form.formState.errors.name && (
+                    <p className="text-sm text-destructive mt-1">
+                      {form.formState.errors.name.message}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="brand">Marke</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="brand"
+                      {...form.register('brand')}
+                      className="mt-1"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm">{item?.brand || '—'}</p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="model">Modell</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="model"
+                      {...form.register('model')}
+                      className="mt-1"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm">{item?.model || '—'}</p>
+                  )}
+                </div>
+
+                <div className="col-span-2">
+                  <Label htmlFor="description">Beschreibung</Label>
+                  {isEditMode ? (
+                    <Textarea
+                      id="description"
+                      {...form.register('description')}
+                      className="mt-1"
+                      rows={3}
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm whitespace-pre-wrap">
+                      {item?.description || '—'}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="category">Kategorien *</Label>
+                  {isEditMode ? (
+                    <select
+                      id="category"
+                      {...form.register('category')}
+                      multiple
+                      className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm min-h-[100px]"
+                    >
+                      {Object.entries(categoryLabels).map(([value, label]) => (
+                        <option key={value} value={value}>
+                          {label}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {item?.category && item.category.length > 0 ? (
+                        item.category.map((cat) => (
+                          <Badge key={cat} variant="secondary">
+                            {categoryLabels[cat as keyof typeof categoryLabels]}
+                          </Badge>
+                        ))
+                      ) : (
+                        <span className="text-sm">—</span>
+                      )}
+                    </div>
+                  )}
+                  <p className="text-xs text-muted-foreground mt-1">
+                    {isEditMode && 'Halten Sie Strg/Cmd für Mehrfachauswahl'}
+                  </p>
+                </div>
+
+                <div>
+                  <Label htmlFor="deposit">Kaution (€) *</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="deposit"
+                      type="number"
+                      step="0.01"
+                      {...form.register('deposit', { valueAsNumber: true })}
+                      className="mt-1"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm">{formatCurrency(item?.deposit || 0)}</p>
+                  )}
+                  {form.formState.errors.deposit && (
+                    <p className="text-sm text-destructive mt-1">
+                      {form.formState.errors.deposit.message}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="copies">Anzahl *</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="copies"
+                      type="number"
+                      {...form.register('copies', { valueAsNumber: true })}
+                      className="mt-1"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm">{item?.copies || 0}</p>
+                  )}
+                  {form.formState.errors.copies && (
+                    <p className="text-sm text-destructive mt-1">
+                      {form.formState.errors.copies.message}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="status">Status *</Label>
+                  {isEditMode ? (
+                    <select
+                      id="status"
+                      {...form.register('status')}
+                      className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    >
+                      <option value="instock">Auf Lager</option>
+                      <option value="outofstock">Ausgeliehen</option>
+                      <option value="reserved">Reserviert</option>
+                      <option value="onbackorder">Nachbestellt</option>
+                      <option value="lost">Verloren</option>
+                      <option value="repairing">Reparatur</option>
+                      <option value="forsale">Zu verkaufen</option>
+                      <option value="deleted">Gelöscht</option>
+                    </select>
+                  ) : (
+                    <div className="mt-1">{getStatusBadge(item?.status || 'instock')}</div>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            {/* Details */}
+            <section>
+              <h3 className="font-semibold text-lg mb-4">Details</h3>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="col-span-2">
+                  <Label htmlFor="synonyms">Synonyme</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="synonyms"
+                      {...form.register('synonyms')}
+                      className="mt-1"
+                      placeholder="Komma-getrennt"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm">
+                      {item?.synonyms && item.synonyms.length > 0
+                        ? item.synonyms.join(', ')
+                        : '—'}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="packaging">Verpackung</Label>
+                  {isEditMode ? (
+                    <Textarea
+                      id="packaging"
+                      {...form.register('packaging')}
+                      className="mt-1"
+                      rows={2}
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm whitespace-pre-wrap">
+                      {item?.packaging || '—'}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="manual">Anleitung</Label>
+                  {isEditMode ? (
+                    <Textarea
+                      id="manual"
+                      {...form.register('manual')}
+                      className="mt-1"
+                      rows={2}
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm whitespace-pre-wrap">
+                      {item?.manual || '—'}
+                    </p>
+                  )}
+                </div>
+
+                <div className="col-span-2">
+                  <Label htmlFor="parts">Teile</Label>
+                  {isEditMode ? (
+                    <Textarea
+                      id="parts"
+                      {...form.register('parts')}
+                      className="mt-1"
+                      rows={2}
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm whitespace-pre-wrap">
+                      {item?.parts || '—'}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            {/* Additional Information */}
+            <section>
+              <h3 className="font-semibold text-lg mb-4">Zusätzliche Informationen</h3>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="added_on">Hinzugefügt am</Label>
+                  {isEditMode ? (
+                    <Input
+                      id="added_on"
+                      type="date"
+                      {...form.register('added_on')}
+                      className="mt-1"
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm">
+                      {item ? formatDate(item.added_on) : '—'}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="highlight_color">Markierungsfarbe</Label>
+                  {isEditMode ? (
+                    <select
+                      id="highlight_color"
+                      {...form.register('highlight_color')}
+                      className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    >
+                      <option value="">Keine</option>
+                      <option value="green">Grün</option>
+                      <option value="blue">Blau</option>
+                      <option value="yellow">Gelb</option>
+                      <option value="red">Rot</option>
+                    </select>
+                  ) : (
+                    <div className="mt-1">
+                      {getHighlightColorBadge(item?.highlight_color) || <span className="text-sm">—</span>}
+                    </div>
+                  )}
+                </div>
+
+                <div className="col-span-2">
+                  <Label htmlFor="internal_note">Interne Notiz</Label>
+                  {isEditMode ? (
+                    <Textarea
+                      id="internal_note"
+                      {...form.register('internal_note')}
+                      className="mt-1"
+                      rows={3}
+                    />
+                  ) : (
+                    <p className="mt-1 text-sm whitespace-pre-wrap">
+                      {item?.internal_note || '—'}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            {/* Rental History */}
+            {!isNewItem && (
+              <section>
+                <h3 className="font-semibold text-lg mb-4">Leihverlauf</h3>
+                {isLoadingHistory ? (
+                  <div className="flex justify-center py-4">
+                    <div className="h-6 w-6 animate-spin border-4 border-primary border-t-transparent rounded-full" />
+                  </div>
+                ) : rentals.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">Keine Leihvorgänge</p>
+                ) : (
+                  <div className="border rounded-md overflow-hidden">
+                    <table className="w-full text-sm">
+                      <thead className="bg-muted">
+                        <tr>
+                          <th className="px-3 py-2 text-left">Kunde</th>
+                          <th className="px-3 py-2 text-left">Ausgeliehen</th>
+                          <th className="px-3 py-2 text-left">Erwartet</th>
+                          <th className="px-3 py-2 text-left">Zurückgegeben</th>
+                          <th className="px-3 py-2 text-left">Status</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {rentals.map((rental) => {
+                          const status = calculateRentalStatus(
+                            rental.rented_on,
+                            rental.returned_on,
+                            rental.expected_on,
+                            rental.extended_on
+                          );
+                          return (
+                            <tr key={rental.id} className="border-t">
+                              <td className="px-3 py-2">
+                                {rental.expand?.customer
+                                  ? `${rental.expand.customer.firstname} ${rental.expand.customer.lastname}`
+                                  : '—'}
+                              </td>
+                              <td className="px-3 py-2">{formatDate(rental.rented_on)}</td>
+                              <td className="px-3 py-2">{formatDate(rental.expected_on)}</td>
+                              <td className="px-3 py-2">
+                                {rental.returned_on ? formatDate(rental.returned_on) : '—'}
+                              </td>
+                              <td className="px-3 py-2">
+                                <Badge variant={status === 'overdue' ? 'destructive' : 'secondary'}>
+                                  {status}
+                                </Badge>
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </section>
+            )}
+          </form>
+
+          {isEditMode && (
+            <SheetFooter className="border-t pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleCancel}
+                disabled={isLoading}
+              >
+                <XIcon className="size-4 mr-2" />
+                Abbrechen
+              </Button>
+              <Button
+                type="submit"
+                onClick={form.handleSubmit(handleSave)}
+                disabled={isLoading}
+              >
+                <SaveIcon className="size-4 mr-2" />
+                {isLoading ? 'Speichern...' : 'Speichern'}
+              </Button>
+            </SheetFooter>
+          )}
+        </SheetContent>
+      </Sheet>
+
+      {/* Cancel Confirmation Dialog */}
+      <Dialog open={showCancelDialog} onOpenChange={setShowCancelDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Änderungen verwerfen?</DialogTitle>
+            <DialogDescription>
+              Sie haben ungespeicherte Änderungen. Möchten Sie diese wirklich verwerfen?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowCancelDialog(false)}>
+              Zurück
+            </Button>
+            <Button variant="destructive" onClick={handleConfirmCancel}>
+              Verwerfen
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/detail-sheets/rental-detail-sheet.tsx
+++ b/components/detail-sheets/rental-detail-sheet.tsx
@@ -1,0 +1,505 @@
+/**
+ * Rental Detail Sheet Component
+ * Displays and edits rental information (edit mode by default)
+ */
+
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { SaveIcon, XIcon } from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetFooter,
+} from '@/components/ui/sheet';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { collections } from '@/lib/pocketbase/client';
+import { formatDate, formatCurrency, calculateRentalStatus } from '@/lib/utils/formatting';
+import type { Rental, RentalExpanded, Customer, Item } from '@/types';
+
+// Validation schema
+const rentalSchema = z.object({
+  customer_id: z.string().min(1, 'Kunde ist erforderlich'),
+  item_ids: z.array(z.string()).min(1, 'Mindestens ein Artikel ist erforderlich'),
+  deposit: z.number().min(0, 'Kaution muss positiv sein'),
+  deposit_back: z.number().min(0, 'Rückkaution muss positiv sein'),
+  rented_on: z.string(),
+  returned_on: z.string().optional(),
+  expected_on: z.string(),
+  extended_on: z.string().optional(),
+  remark: z.string().optional(),
+  employee: z.string().optional(),
+  employee_back: z.string().optional(),
+});
+
+type RentalFormValues = z.infer<typeof rentalSchema>;
+
+interface RentalDetailSheetProps {
+  rental: RentalExpanded | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave?: (rental: Rental) => void;
+}
+
+export function RentalDetailSheet({
+  rental,
+  open,
+  onOpenChange,
+  onSave,
+}: RentalDetailSheetProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [customers, setCustomers] = useState<Customer[]>([]);
+  const [items, setItems] = useState<Item[]>([]);
+  const [isLoadingData, setIsLoadingData] = useState(false);
+
+  const isNewRental = !rental?.id;
+
+  const form = useForm<RentalFormValues>({
+    resolver: zodResolver(rentalSchema),
+    defaultValues: {
+      customer_id: '',
+      item_ids: [],
+      deposit: 0,
+      deposit_back: 0,
+      rented_on: new Date().toISOString().split('T')[0],
+      returned_on: '',
+      expected_on: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0], // +7 days
+      extended_on: '',
+      remark: '',
+      employee: '',
+      employee_back: '',
+    },
+  });
+
+  const { formState: { isDirty } } = form;
+
+  // Load customers and items for dropdowns
+  useEffect(() => {
+    if (open) {
+      loadData();
+    }
+  }, [open]);
+
+  const loadData = async () => {
+    setIsLoadingData(true);
+    try {
+      // Load customers
+      const customersResult = await collections.customers().getList<Customer>(1, 500, {
+        sort: 'lastname,firstname',
+      });
+      setCustomers(customersResult.items);
+
+      // Load items
+      const itemsResult = await collections.items().getList<Item>(1, 500, {
+        sort: 'name',
+        filter: 'status!="deleted"',
+      });
+      setItems(itemsResult.items);
+    } catch (err) {
+      console.error('Error loading data:', err);
+      toast.error('Fehler beim Laden der Daten');
+    } finally {
+      setIsLoadingData(false);
+    }
+  };
+
+  // Load rental data when rental changes
+  useEffect(() => {
+    if (rental) {
+      form.reset({
+        customer_id: rental.customer,
+        item_ids: rental.items,
+        deposit: rental.deposit,
+        deposit_back: rental.deposit_back,
+        rented_on: rental.rented_on.split('T')[0],
+        returned_on: rental.returned_on?.split('T')[0] || '',
+        expected_on: rental.expected_on.split('T')[0],
+        extended_on: rental.extended_on?.split('T')[0] || '',
+        remark: rental.remark || '',
+        employee: rental.employee || '',
+        employee_back: rental.employee_back || '',
+      });
+    } else if (isNewRental) {
+      form.reset({
+        customer_id: '',
+        item_ids: [],
+        deposit: 0,
+        deposit_back: 0,
+        rented_on: new Date().toISOString().split('T')[0],
+        returned_on: '',
+        expected_on: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+        extended_on: '',
+        remark: '',
+        employee: '',
+        employee_back: '',
+      });
+    }
+  }, [rental, isNewRental, form]);
+
+  const handleSave = async (data: RentalFormValues) => {
+    setIsLoading(true);
+    try {
+      const formData: Partial<Rental> = {
+        customer: data.customer_id,
+        items: data.item_ids,
+        deposit: data.deposit,
+        deposit_back: data.deposit_back,
+        rented_on: data.rented_on,
+        returned_on: data.returned_on || undefined,
+        expected_on: data.expected_on,
+        extended_on: data.extended_on || undefined,
+        remark: data.remark || undefined,
+        employee: data.employee || undefined,
+        employee_back: data.employee_back || undefined,
+      };
+
+      let savedRental: Rental;
+      if (isNewRental) {
+        savedRental = await collections.rentals().create<Rental>(formData);
+        toast.success('Leihvorgang erfolgreich erstellt');
+      } else if (rental) {
+        savedRental = await collections.rentals().update<Rental>(rental.id, formData);
+        toast.success('Leihvorgang erfolgreich aktualisiert');
+      } else {
+        return;
+      }
+
+      onSave?.(savedRental);
+      onOpenChange(false);
+    } catch (err) {
+      console.error('Error saving rental:', err);
+      toast.error('Fehler beim Speichern des Leihvorgangs');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    if (isDirty) {
+      setShowCancelDialog(true);
+    } else {
+      onOpenChange(false);
+    }
+  };
+
+  const handleConfirmCancel = () => {
+    setShowCancelDialog(false);
+    form.reset();
+    onOpenChange(false);
+  };
+
+  const rentalStatus = rental
+    ? calculateRentalStatus(
+        rental.rented_on,
+        rental.returned_on,
+        rental.expected_on,
+        rental.extended_on
+      )
+    : null;
+
+  const getStatusBadge = (status: string) => {
+    const statusMap = {
+      active: { label: 'Aktiv', variant: 'default' as const },
+      returned: { label: 'Zurückgegeben', variant: 'secondary' as const },
+      overdue: { label: 'Überfällig', variant: 'destructive' as const },
+      due_today: { label: 'Heute fällig', variant: 'secondary' as const },
+      returned_today: { label: 'Heute zurückgegeben', variant: 'secondary' as const },
+    };
+    const { label, variant } = statusMap[status as keyof typeof statusMap] || statusMap.active;
+    return <Badge variant={variant}>{label}</Badge>;
+  };
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={(open) => {
+        if (!open && isDirty) {
+          setShowCancelDialog(true);
+        } else {
+          onOpenChange(open);
+        }
+      }}>
+        <SheetContent className="w-full sm:max-w-4xl overflow-y-auto">
+          <SheetHeader className="border-b pb-4">
+            <div className="flex items-center justify-between">
+              <SheetTitle>
+                {isNewRental ? 'Neuer Leihvorgang' : 'Leihvorgang bearbeiten'}
+              </SheetTitle>
+              {rentalStatus && (
+                <div>{getStatusBadge(rentalStatus)}</div>
+              )}
+            </div>
+          </SheetHeader>
+
+          <form onSubmit={form.handleSubmit(handleSave)} className="space-y-6 py-6">
+            {/* Customer and Items */}
+            <section>
+              <h3 className="font-semibold text-lg mb-4">Kunde & Artikel</h3>
+              <div className="space-y-4">
+                <div>
+                  <Label htmlFor="customer_id">Kunde *</Label>
+                  <select
+                    id="customer_id"
+                    {...form.register('customer_id')}
+                    className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    disabled={isLoadingData}
+                  >
+                    <option value="">Kunde auswählen...</option>
+                    {customers.map((customer) => (
+                      <option key={customer.id} value={customer.id}>
+                        #{String(customer.iid).padStart(4, '0')} - {customer.firstname} {customer.lastname}
+                      </option>
+                    ))}
+                  </select>
+                  {form.formState.errors.customer_id && (
+                    <p className="text-sm text-destructive mt-1">
+                      {form.formState.errors.customer_id.message}
+                    </p>
+                  )}
+                  {/* Show expanded customer details if editing */}
+                  {rental?.expand?.customer && (
+                    <div className="mt-2 p-3 bg-muted rounded-md text-sm">
+                      <p className="font-medium">
+                        {rental.expand.customer.firstname} {rental.expand.customer.lastname}
+                      </p>
+                      {rental.expand.customer.email && (
+                        <p className="text-muted-foreground">{rental.expand.customer.email}</p>
+                      )}
+                      {rental.expand.customer.phone && (
+                        <p className="text-muted-foreground">{rental.expand.customer.phone}</p>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="item_ids">Artikel *</Label>
+                  <select
+                    id="item_ids"
+                    {...form.register('item_ids')}
+                    multiple
+                    className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm min-h-[150px]"
+                    disabled={isLoadingData}
+                  >
+                    {items.map((item) => (
+                      <option key={item.id} value={item.id}>
+                        #{String(item.iid).padStart(4, '0')} - {item.name} ({formatCurrency(item.deposit)})
+                      </option>
+                    ))}
+                  </select>
+                  {form.formState.errors.item_ids && (
+                    <p className="text-sm text-destructive mt-1">
+                      {form.formState.errors.item_ids.message}
+                    </p>
+                  )}
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Halten Sie Strg/Cmd für Mehrfachauswahl
+                  </p>
+                  {/* Show expanded item details if editing */}
+                  {rental?.expand?.items && rental.expand.items.length > 0 && (
+                    <div className="mt-2 space-y-2">
+                      {rental.expand.items.map((item) => (
+                        <div key={item.id} className="p-3 bg-muted rounded-md text-sm">
+                          <p className="font-medium">{item.name}</p>
+                          <p className="text-muted-foreground">
+                            Kaution: {formatCurrency(item.deposit)}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            {/* Dates */}
+            <section>
+              <h3 className="font-semibold text-lg mb-4">Zeitraum</h3>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="rented_on">Ausgeliehen am *</Label>
+                  <Input
+                    id="rented_on"
+                    type="date"
+                    {...form.register('rented_on')}
+                    className="mt-1"
+                  />
+                  {form.formState.errors.rented_on && (
+                    <p className="text-sm text-destructive mt-1">
+                      {form.formState.errors.rented_on.message}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="expected_on">Erwartet am *</Label>
+                  <Input
+                    id="expected_on"
+                    type="date"
+                    {...form.register('expected_on')}
+                    className="mt-1"
+                  />
+                  {form.formState.errors.expected_on && (
+                    <p className="text-sm text-destructive mt-1">
+                      {form.formState.errors.expected_on.message}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="extended_on">Verlängert bis</Label>
+                  <Input
+                    id="extended_on"
+                    type="date"
+                    {...form.register('extended_on')}
+                    className="mt-1"
+                  />
+                </div>
+
+                <div>
+                  <Label htmlFor="returned_on">Zurückgegeben am</Label>
+                  <Input
+                    id="returned_on"
+                    type="date"
+                    {...form.register('returned_on')}
+                    className="mt-1"
+                  />
+                </div>
+              </div>
+            </section>
+
+            {/* Financial */}
+            <section>
+              <h3 className="font-semibold text-lg mb-4">Kaution</h3>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="deposit">Kaution gegeben (€) *</Label>
+                  <Input
+                    id="deposit"
+                    type="number"
+                    step="0.01"
+                    {...form.register('deposit', { valueAsNumber: true })}
+                    className="mt-1"
+                  />
+                  {form.formState.errors.deposit && (
+                    <p className="text-sm text-destructive mt-1">
+                      {form.formState.errors.deposit.message}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="deposit_back">Kaution zurückgegeben (€) *</Label>
+                  <Input
+                    id="deposit_back"
+                    type="number"
+                    step="0.01"
+                    {...form.register('deposit_back', { valueAsNumber: true })}
+                    className="mt-1"
+                  />
+                  {form.formState.errors.deposit_back && (
+                    <p className="text-sm text-destructive mt-1">
+                      {form.formState.errors.deposit_back.message}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            {/* Additional Information */}
+            <section>
+              <h3 className="font-semibold text-lg mb-4">Zusätzliche Informationen</h3>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="employee">Mitarbeiter (Ausgabe)</Label>
+                  <Input
+                    id="employee"
+                    {...form.register('employee')}
+                    className="mt-1"
+                  />
+                </div>
+
+                <div>
+                  <Label htmlFor="employee_back">Mitarbeiter (Rückgabe)</Label>
+                  <Input
+                    id="employee_back"
+                    {...form.register('employee_back')}
+                    className="mt-1"
+                  />
+                </div>
+
+                <div className="col-span-2">
+                  <Label htmlFor="remark">Bemerkung</Label>
+                  <Textarea
+                    id="remark"
+                    {...form.register('remark')}
+                    className="mt-1"
+                    rows={3}
+                  />
+                </div>
+              </div>
+            </section>
+          </form>
+
+          <SheetFooter className="border-t pt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleCancel}
+              disabled={isLoading}
+            >
+              <XIcon className="size-4 mr-2" />
+              Abbrechen
+            </Button>
+            <Button
+              type="submit"
+              onClick={form.handleSubmit(handleSave)}
+              disabled={isLoading || isLoadingData}
+            >
+              <SaveIcon className="size-4 mr-2" />
+              {isLoading ? 'Speichern...' : 'Speichern'}
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+
+      {/* Cancel Confirmation Dialog */}
+      <Dialog open={showCancelDialog} onOpenChange={setShowCancelDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Änderungen verwerfen?</DialogTitle>
+            <DialogDescription>
+              Sie haben ungespeicherte Änderungen. Möchten Sie diese wirklich verwerfen?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowCancelDialog(false)}>
+              Zurück
+            </Button>
+            <Button variant="destructive" onClick={handleConfirmCancel}>
+              Verwerfen
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/detail-sheets/reservation-detail-sheet.tsx
+++ b/components/detail-sheets/reservation-detail-sheet.tsx
@@ -1,0 +1,445 @@
+/**
+ * Reservation Detail Sheet Component
+ * Displays and edits reservation information (edit mode by default)
+ */
+
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { SaveIcon, XIcon } from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetFooter,
+} from '@/components/ui/sheet';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { collections } from '@/lib/pocketbase/client';
+import { formatDate, formatCurrency } from '@/lib/utils/formatting';
+import type { Reservation, ReservationExpanded, Customer, Item } from '@/types';
+
+// Validation schema
+const reservationSchema = z.object({
+  customer_iid: z.number().optional(),
+  customer_name: z.string().min(1, 'Kundenname ist erforderlich'),
+  customer_phone: z.string().optional(),
+  customer_email: z.string().email('Ungültige E-Mail-Adresse').optional().or(z.literal('')),
+  is_new_customer: z.boolean(),
+  item_ids: z.array(z.string()).min(1, 'Mindestens ein Artikel ist erforderlich'),
+  pickup: z.string(),
+  comments: z.string().optional(),
+  done: z.boolean(),
+});
+
+type ReservationFormValues = z.infer<typeof reservationSchema>;
+
+interface ReservationDetailSheetProps {
+  reservation: ReservationExpanded | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave?: (reservation: Reservation) => void;
+}
+
+export function ReservationDetailSheet({
+  reservation,
+  open,
+  onOpenChange,
+  onSave,
+}: ReservationDetailSheetProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [customers, setCustomers] = useState<Customer[]>([]);
+  const [items, setItems] = useState<Item[]>([]);
+  const [isLoadingData, setIsLoadingData] = useState(false);
+
+  const isNewReservation = !reservation?.id;
+
+  const form = useForm<ReservationFormValues>({
+    resolver: zodResolver(reservationSchema),
+    defaultValues: {
+      customer_iid: undefined,
+      customer_name: '',
+      customer_phone: '',
+      customer_email: '',
+      is_new_customer: false,
+      item_ids: [],
+      pickup: new Date().toISOString().slice(0, 16), // YYYY-MM-DDTHH:MM
+      comments: '',
+      done: false,
+    },
+  });
+
+  const { formState: { isDirty }, watch } = form;
+  const isNewCustomer = watch('is_new_customer');
+  const selectedCustomerIid = watch('customer_iid');
+
+  // Load customers and items for dropdowns
+  useEffect(() => {
+    if (open) {
+      loadData();
+    }
+  }, [open]);
+
+  const loadData = async () => {
+    setIsLoadingData(true);
+    try {
+      // Load customers
+      const customersResult = await collections.customers().getList<Customer>(1, 500, {
+        sort: 'lastname,firstname',
+      });
+      setCustomers(customersResult.items);
+
+      // Load items
+      const itemsResult = await collections.items().getList<Item>(1, 500, {
+        sort: 'name',
+        filter: 'status!="deleted"',
+      });
+      setItems(itemsResult.items);
+    } catch (err) {
+      console.error('Error loading data:', err);
+      toast.error('Fehler beim Laden der Daten');
+    } finally {
+      setIsLoadingData(false);
+    }
+  };
+
+  // Auto-fill customer name when selecting existing customer
+  useEffect(() => {
+    if (!isNewCustomer && selectedCustomerIid) {
+      const customer = customers.find((c) => c.iid === selectedCustomerIid);
+      if (customer) {
+        form.setValue('customer_name', `${customer.firstname} ${customer.lastname}`);
+        form.setValue('customer_phone', customer.phone || '');
+        form.setValue('customer_email', customer.email || '');
+      }
+    }
+  }, [selectedCustomerIid, isNewCustomer, customers, form]);
+
+  // Load reservation data when reservation changes
+  useEffect(() => {
+    if (reservation) {
+      form.reset({
+        customer_iid: reservation.customer_iid || undefined,
+        customer_name: reservation.customer_name,
+        customer_phone: reservation.customer_phone || '',
+        customer_email: reservation.customer_email || '',
+        is_new_customer: reservation.is_new_customer,
+        item_ids: reservation.items,
+        pickup: reservation.pickup.slice(0, 16), // Convert to datetime-local format
+        comments: reservation.comments || '',
+        done: reservation.done,
+      });
+    } else if (isNewReservation) {
+      form.reset({
+        customer_iid: undefined,
+        customer_name: '',
+        customer_phone: '',
+        customer_email: '',
+        is_new_customer: false,
+        item_ids: [],
+        pickup: new Date().toISOString().slice(0, 16),
+        comments: '',
+        done: false,
+      });
+    }
+  }, [reservation, isNewReservation, form]);
+
+  const handleSave = async (data: ReservationFormValues) => {
+    setIsLoading(true);
+    try {
+      const formData: Partial<Reservation> = {
+        customer_iid: data.is_new_customer ? undefined : data.customer_iid,
+        customer_name: data.customer_name,
+        customer_phone: data.customer_phone || undefined,
+        customer_email: data.customer_email || undefined,
+        is_new_customer: data.is_new_customer,
+        items: data.item_ids,
+        pickup: data.pickup,
+        comments: data.comments || undefined,
+        done: data.done,
+      };
+
+      let savedReservation: Reservation;
+      if (isNewReservation) {
+        savedReservation = await collections.reservations().create<Reservation>(formData);
+        toast.success('Reservierung erfolgreich erstellt');
+      } else if (reservation) {
+        savedReservation = await collections.reservations().update<Reservation>(reservation.id, formData);
+        toast.success('Reservierung erfolgreich aktualisiert');
+      } else {
+        return;
+      }
+
+      onSave?.(savedReservation);
+      onOpenChange(false);
+    } catch (err) {
+      console.error('Error saving reservation:', err);
+      toast.error('Fehler beim Speichern der Reservierung');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    if (isDirty) {
+      setShowCancelDialog(true);
+    } else {
+      onOpenChange(false);
+    }
+  };
+
+  const handleConfirmCancel = () => {
+    setShowCancelDialog(false);
+    form.reset();
+    onOpenChange(false);
+  };
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={(open) => {
+        if (!open && isDirty) {
+          setShowCancelDialog(true);
+        } else {
+          onOpenChange(open);
+        }
+      }}>
+        <SheetContent className="w-full sm:max-w-4xl overflow-y-auto">
+          <SheetHeader className="border-b pb-4">
+            <div className="flex items-center justify-between">
+              <SheetTitle>
+                {isNewReservation ? 'Neue Reservierung' : 'Reservierung bearbeiten'}
+              </SheetTitle>
+              {reservation && (
+                <Badge variant={reservation.done ? 'secondary' : 'default'}>
+                  {reservation.done ? 'Erledigt' : 'Offen'}
+                </Badge>
+              )}
+            </div>
+          </SheetHeader>
+
+          <form onSubmit={form.handleSubmit(handleSave)} className="space-y-6 py-6">
+            {/* Customer Information */}
+            <section>
+              <h3 className="font-semibold text-lg mb-4">Kundeninformationen</h3>
+              <div className="space-y-4">
+                <div className="flex items-center gap-2">
+                  <input
+                    id="is_new_customer"
+                    type="checkbox"
+                    {...form.register('is_new_customer')}
+                  />
+                  <Label htmlFor="is_new_customer" className="cursor-pointer">
+                    Neuer Kunde (noch nicht registriert)
+                  </Label>
+                </div>
+
+                {!isNewCustomer && (
+                  <div>
+                    <Label htmlFor="customer_iid">Bestehender Kunde</Label>
+                    <select
+                      id="customer_iid"
+                      {...form.register('customer_iid', { valueAsNumber: true })}
+                      className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                      disabled={isLoadingData}
+                    >
+                      <option value="">Kunde auswählen...</option>
+                      {customers.map((customer) => (
+                        <option key={customer.id} value={customer.iid}>
+                          #{String(customer.iid).padStart(4, '0')} - {customer.firstname} {customer.lastname}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+
+                <div>
+                  <Label htmlFor="customer_name">Name *</Label>
+                  <Input
+                    id="customer_name"
+                    {...form.register('customer_name')}
+                    className="mt-1"
+                    readOnly={!isNewCustomer && !!selectedCustomerIid}
+                  />
+                  {form.formState.errors.customer_name && (
+                    <p className="text-sm text-destructive mt-1">
+                      {form.formState.errors.customer_name.message}
+                    </p>
+                  )}
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="customer_phone">Telefon</Label>
+                    <Input
+                      id="customer_phone"
+                      {...form.register('customer_phone')}
+                      className="mt-1"
+                      readOnly={!isNewCustomer && !!selectedCustomerIid}
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor="customer_email">E-Mail</Label>
+                    <Input
+                      id="customer_email"
+                      type="email"
+                      {...form.register('customer_email')}
+                      className="mt-1"
+                      readOnly={!isNewCustomer && !!selectedCustomerIid}
+                    />
+                    {form.formState.errors.customer_email && (
+                      <p className="text-sm text-destructive mt-1">
+                        {form.formState.errors.customer_email.message}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            {/* Items */}
+            <section>
+              <h3 className="font-semibold text-lg mb-4">Artikel</h3>
+              <div>
+                <Label htmlFor="item_ids">Artikel *</Label>
+                <select
+                  id="item_ids"
+                  {...form.register('item_ids')}
+                  multiple
+                  className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm min-h-[150px]"
+                  disabled={isLoadingData}
+                >
+                  {items.map((item) => (
+                    <option key={item.id} value={item.id}>
+                      #{String(item.iid).padStart(4, '0')} - {item.name} ({formatCurrency(item.deposit)})
+                    </option>
+                  ))}
+                </select>
+                {form.formState.errors.item_ids && (
+                  <p className="text-sm text-destructive mt-1">
+                    {form.formState.errors.item_ids.message}
+                  </p>
+                )}
+                <p className="text-xs text-muted-foreground mt-1">
+                  Halten Sie Strg/Cmd für Mehrfachauswahl
+                </p>
+                {/* Show expanded item details if editing */}
+                {reservation?.expand?.items && reservation.expand.items.length > 0 && (
+                  <div className="mt-2 space-y-2">
+                    {reservation.expand.items.map((item) => (
+                      <div key={item.id} className="p-3 bg-muted rounded-md text-sm">
+                        <p className="font-medium">{item.name}</p>
+                        <p className="text-muted-foreground">
+                          Kaution: {formatCurrency(item.deposit)}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </section>
+
+            {/* Reservation Details */}
+            <section>
+              <h3 className="font-semibold text-lg mb-4">Reservierungsdetails</h3>
+              <div className="space-y-4">
+                <div>
+                  <Label htmlFor="pickup">Abholung (Datum & Zeit) *</Label>
+                  <Input
+                    id="pickup"
+                    type="datetime-local"
+                    {...form.register('pickup')}
+                    className="mt-1"
+                  />
+                  {form.formState.errors.pickup && (
+                    <p className="text-sm text-destructive mt-1">
+                      {form.formState.errors.pickup.message}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <Label htmlFor="comments">Kommentar</Label>
+                  <Textarea
+                    id="comments"
+                    {...form.register('comments')}
+                    className="mt-1"
+                    rows={3}
+                  />
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <input
+                    id="done"
+                    type="checkbox"
+                    {...form.register('done')}
+                  />
+                  <Label htmlFor="done" className="cursor-pointer">
+                    Reservierung erledigt
+                  </Label>
+                </div>
+              </div>
+            </section>
+          </form>
+
+          <SheetFooter className="border-t pt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleCancel}
+              disabled={isLoading}
+            >
+              <XIcon className="size-4 mr-2" />
+              Abbrechen
+            </Button>
+            <Button
+              type="submit"
+              onClick={form.handleSubmit(handleSave)}
+              disabled={isLoading || isLoadingData}
+            >
+              <SaveIcon className="size-4 mr-2" />
+              {isLoading ? 'Speichern...' : 'Speichern'}
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+
+      {/* Cancel Confirmation Dialog */}
+      <Dialog open={showCancelDialog} onOpenChange={setShowCancelDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Änderungen verwerfen?</DialogTitle>
+            <DialogDescription>
+              Sie haben ungespeicherte Änderungen. Möchten Sie diese wirklich verwerfen?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowCancelDialog(false)}>
+              Zurück
+            </Button>
+            <Button variant="destructive" onClick={handleConfirmCancel}>
+              Verwerfen
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
- Create CustomerDetailSheet with read-only/edit modes
  - Shows rental and reservation history
  - Includes all customer fields with validation

- Create ItemDetailSheet with read-only/edit modes
  - Shows rental history
  - Includes category selection and status management

- Create RentalDetailSheet (edit mode by default)
  - Customer and item selection dropdowns
  - Expanded customer/item details display
  - Date and deposit management

- Create ReservationDetailSheet (edit mode by default)
  - New/existing customer handling
  - Item selection with details
  - Pickup date/time management

- Integrate all sheets into respective pages:
  - Add "New" buttons to toolbars
  - Make table rows clickable
  - Handle data refresh on save

- Features:
  - Confirmation dialog for unsaved changes
  - Form validation with Zod
  - Multi-column desktop-optimized layouts
  - Related data display (history, expanded relations)