### PR TITLE
Fix synonyms join error in item detail sheet

### DIFF
--- a/components/detail-sheets/item-detail-sheet.tsx
+++ b/components/detail-sheets/item-detail-sheet.tsx
@@ -524,7 +524,7 @@ export function ItemDetailSheet({
                   ) : (
                     <p className="mt-1 text-sm">
                       {item?.synonyms && item.synonyms.length > 0
-                        ? item.synonyms.join(', ')
+                        ? (Array.isArray(item.synonyms) ? item.synonyms.join(', ') : item.synonyms)
                         : '—'}
                     </p>
                   )}


### PR DESCRIPTION
Added safety check to handle synonyms field when it might be a string instead of an array. The display code now checks if synonyms is an array before calling .join(), matching the same pattern used when loading the form data.

Fixes runtime error: "item.synonyms.join is not a function"