### PR TITLE
Add image functionality to items table and detail view

### DIFF
--- a/app/(dashboard)/items/page.tsx
+++ b/app/(dashboard)/items/page.tsx
@@ -5,15 +5,16 @@
 'use client';
 
 import { useEffect, useState, useRef, useCallback } from 'react';
-import { PlusIcon } from 'lucide-react';
+import { PlusIcon, ImageIcon } from 'lucide-react';
 import { SearchBar } from '@/components/search/search-bar';
 import { FilterPopover } from '@/components/search/filter-popover';
 import { SortableHeader, type SortDirection } from '@/components/table/sortable-header';
 import { ColumnSelector } from '@/components/table/column-selector';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card';
 import { ItemDetailSheet } from '@/components/detail-sheets/item-detail-sheet';
-import { collections } from '@/lib/pocketbase/client';
+import { collections, pb } from '@/lib/pocketbase/client';
 import { useFilters } from '@/hooks/use-filters';
 import { useColumnVisibility } from '@/hooks/use-column-visibility';
 import { itemsFilterConfig } from '@/lib/filters/filter-configs';
@@ -259,6 +260,11 @@ export default function ItemsPage() {
                           />
                         </th>
                       )}
+                      {columnVisibility.isColumnVisible('images') && (
+                        <th className="px-4 py-2 text-left">
+                          <span className="text-sm font-medium">Bild</span>
+                        </th>
+                      )}
                       {columnVisibility.isColumnVisible('name') && (
                         <th className="px-4 py-2 text-left">
                           <SortableHeader
@@ -401,6 +407,39 @@ export default function ItemsPage() {
                         {columnVisibility.isColumnVisible('iid') && (
                           <td className="px-4 py-3 font-mono text-sm">
                             {String(item.iid).padStart(4, '0')}
+                          </td>
+                        )}
+                        {columnVisibility.isColumnVisible('images') && (
+                          <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                            {item.images && item.images.length > 0 ? (
+                              <HoverCard openDelay={200}>
+                                <HoverCardTrigger asChild>
+                                  <div className="w-10 h-10 rounded overflow-hidden border border-border cursor-pointer">
+                                    <img
+                                      src={pb.files.getUrl(item, item.images[0], { thumb: '40x40' })}
+                                      alt={item.name}
+                                      className="w-full h-full object-cover"
+                                    />
+                                  </div>
+                                </HoverCardTrigger>
+                                <HoverCardContent className="w-80 p-2">
+                                  <img
+                                    src={pb.files.getUrl(item, item.images[0], { thumb: '300x300' })}
+                                    alt={item.name}
+                                    className="w-full h-auto rounded"
+                                  />
+                                  {item.images.length > 1 && (
+                                    <p className="text-xs text-muted-foreground mt-2 text-center">
+                                      +{item.images.length - 1} weitere{item.images.length - 1 === 1 ? 's' : ''} Bild{item.images.length - 1 === 1 ? '' : 'er'}
+                                    </p>
+                                  )}
+                                </HoverCardContent>
+                              </HoverCard>
+                            ) : (
+                              <div className="w-10 h-10 rounded border border-dashed border-border flex items-center justify-center bg-muted/20">
+                                <ImageIcon className="size-4 text-muted-foreground" />
+                              </div>
+                            )}
                           </td>
                         )}
                         {columnVisibility.isColumnVisible('name') && (

--- a/components/ui/hover-card.tsx
+++ b/components/ui/hover-card.tsx
@@ -1,0 +1,30 @@
+/**
+ * HoverCard component - displays content in a popover on hover
+ */
+import * as React from 'react';
+import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
+
+import { cn } from '@/lib/utils';
+
+const HoverCard = HoverCardPrimitive.Root;
+
+const HoverCardTrigger = HoverCardPrimitive.Trigger;
+
+const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+  <HoverCardPrimitive.Content
+    ref={ref}
+    align={align}
+    sideOffset={sideOffset}
+    className={cn(
+      'z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      className
+    )}
+    {...props}
+  />
+));
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
+
+export { HoverCard, HoverCardTrigger, HoverCardContent };

--- a/lib/tables/column-configs.ts
+++ b/lib/tables/column-configs.ts
@@ -112,6 +112,12 @@ export const itemsColumnConfig: EntityColumnConfig = {
       sortable: true,
     },
     {
+      id: 'images',
+      label: 'Bild',
+      defaultVisible: true,
+      sortable: false, // Array field
+    },
+    {
       id: 'name',
       label: 'Name',
       defaultVisible: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-hover-card": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-scroll-area": "^1.2.10",
@@ -3893,6 +3894,78 @@
       }
     },
     "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
+      "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card/node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-scroll-area": "^1.2.10",


### PR DESCRIPTION
- Install HoverCard component from Radix UI
- Add image preview column to items table with hover functionality
  - Show thumbnail in table
  - Display larger preview on hover using HoverCard
  - Show placeholder icon when no images exist
- Add comprehensive image management to ItemDetailSheet
  - Display all images in grid layout (view and edit mode)
  - Upload multiple images at once in edit mode
  - Remove existing or new images with delete button
  - Preview new images before saving
- Update handleSave to use FormData for file uploads
- Support PocketBase file upload and deletion patterns