### PR TITLE
Fix rental date fields not displaying in form inputs

### DIFF
--- a/components/detail-sheets/rental-detail-sheet.tsx
+++ b/components/detail-sheets/rental-detail-sheet.tsx
@@ -140,10 +140,8 @@ export function RentalDetailSheet({
     }
   };
 
-  // Load rental data when rental changes or sheet opens
+  // Load rental data when rental changes
   useEffect(() => {
-    if (!open) return;
-
     if (rental) {
       form.reset({
         customer_id: rental.customer || '',
@@ -173,7 +171,7 @@ export function RentalDetailSheet({
         employee_back: '',
       });
     }
-  }, [rental, open, isNewRental]);
+  }, [rental, isNewRental, form]);
 
   const handleSave = async (data: RentalFormValues) => {
     setIsLoading(true);


### PR DESCRIPTION
- Remove early return check for 'open' prop
- Remove 'open' from useEffect dependencies
- Add 'form' back to dependencies (matching pattern from customer/reservation sheets)

The issue was that checking `if (!open) return` prevented the form from resetting properly. By following the same pattern as customer and reservation detail sheets, the date fields now properly populate in the form inputs.