### PR TITLE
Add category calls to detail view

### DIFF
--- a/components/detail-sheets/item-detail-sheet.tsx
+++ b/components/detail-sheets/item-detail-sheet.tsx
@@ -34,14 +34,15 @@ import { Badge } from '@/components/ui/badge';
 import { collections, pb } from '@/lib/pocketbase/client';
 import { formatDate, formatCurrency, calculateRentalStatus } from '@/lib/utils/formatting';
 import type { Item, ItemFormData, RentalExpanded, ItemCategory, ItemStatus, HighlightColor } from '@/types';
+import { CATEGORY_OPTIONS, GERMAN_CATEGORY_VALUES } from '@/lib/constants/categories';
 
-// Validation schema
+// Validation schema (using German category names as they are stored in PocketBase)
 const itemSchema = z.object({
   name: z.string().min(1, 'Name ist erforderlich'),
   brand: z.string().optional(),
   model: z.string().optional(),
   description: z.string().optional(),
-  category: z.array(z.enum(['kitchen', 'household', 'garden', 'kids', 'leisure', 'diy', 'other'])),
+  category: z.array(z.enum(['Küche', 'Haushalt', 'Garten', 'Kinder', 'Freizeit', 'Heimwerken', 'Sonstiges'])),
   deposit: z.number().min(0, 'Kaution muss positiv sein'),
   synonyms: z.string().optional(), // Comma-separated
   packaging: z.string().optional(),
@@ -313,16 +314,6 @@ export function ItemDetailSheet({
     return <Badge variant={variant}>{label}</Badge>;
   };
 
-  const categoryLabels = {
-    kitchen: 'Küche',
-    household: 'Haushalt',
-    garden: 'Garten',
-    kids: 'Kinder',
-    leisure: 'Freizeit',
-    diy: 'Heimwerken',
-    other: 'Sonstiges',
-  };
-
   return (
     <>
       <Sheet open={open} onOpenChange={(open) => {
@@ -468,7 +459,7 @@ export function ItemDetailSheet({
                       multiple
                       className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm min-h-[100px]"
                     >
-                      {Object.entries(categoryLabels).map(([value, label]) => (
+                      {CATEGORY_OPTIONS.map(({ value, label }) => (
                         <option key={value} value={value}>
                           {label}
                         </option>
@@ -479,7 +470,7 @@ export function ItemDetailSheet({
                       {item?.category && item.category.length > 0 ? (
                         item.category.map((cat) => (
                           <Badge key={cat} variant="secondary">
-                            {categoryLabels[cat as keyof typeof categoryLabels]}
+                            {cat}
                           </Badge>
                         ))
                       ) : (

--- a/lib/constants/categories.ts
+++ b/lib/constants/categories.ts
@@ -5,7 +5,7 @@
 import { ItemCategory } from '@/types';
 
 /**
- * Category labels (German)
+ * Category labels (German) - these are the actual values stored in the database
  */
 export const CATEGORY_LABELS: Record<ItemCategory, string> = {
   [ItemCategory.Kitchen]: 'Küche',
@@ -18,18 +18,44 @@ export const CATEGORY_LABELS: Record<ItemCategory, string> = {
 };
 
 /**
- * Category options for selects/filters
+ * German category values as stored in PocketBase
  */
-export const CATEGORY_OPTIONS = Object.entries(CATEGORY_LABELS).map(
-  ([value, label]) => ({
-    value,
-    label,
-  })
-);
+export const GERMAN_CATEGORIES = {
+  KITCHEN: 'Küche',
+  HOUSEHOLD: 'Haushalt',
+  GARDEN: 'Garten',
+  KIDS: 'Kinder',
+  LEISURE: 'Freizeit',
+  DIY: 'Heimwerken',
+  OTHER: 'Sonstiges',
+} as const;
 
 /**
- * Get category label by value
+ * Array of all German category values
  */
-export function getCategoryLabel(category: ItemCategory): string {
-  return CATEGORY_LABELS[category] || category;
+export const GERMAN_CATEGORY_VALUES = Object.values(GERMAN_CATEGORIES);
+
+/**
+ * Category options for selects/filters (using German values)
+ */
+export const CATEGORY_OPTIONS = [
+  { value: GERMAN_CATEGORIES.KITCHEN, label: GERMAN_CATEGORIES.KITCHEN },
+  { value: GERMAN_CATEGORIES.HOUSEHOLD, label: GERMAN_CATEGORIES.HOUSEHOLD },
+  { value: GERMAN_CATEGORIES.GARDEN, label: GERMAN_CATEGORIES.GARDEN },
+  { value: GERMAN_CATEGORIES.KIDS, label: GERMAN_CATEGORIES.KIDS },
+  { value: GERMAN_CATEGORIES.LEISURE, label: GERMAN_CATEGORIES.LEISURE },
+  { value: GERMAN_CATEGORIES.DIY, label: GERMAN_CATEGORIES.DIY },
+  { value: GERMAN_CATEGORIES.OTHER, label: GERMAN_CATEGORIES.OTHER },
+];
+
+/**
+ * Get category label by value (supports both English enum and German values)
+ */
+export function getCategoryLabel(category: ItemCategory | string): string {
+  // If it's already a German category, return it as is
+  if (GERMAN_CATEGORY_VALUES.includes(category as any)) {
+    return category;
+  }
+  // Otherwise look it up in the labels map
+  return CATEGORY_LABELS[category as ItemCategory] || category;
 }

--- a/lib/filters/filter-configs.ts
+++ b/lib/filters/filter-configs.ts
@@ -7,7 +7,7 @@ import {
   ITEM_STATUS_LABELS,
   RENTAL_STATUS_LABELS,
 } from '@/lib/constants/statuses';
-import { CATEGORY_LABELS } from '@/lib/constants/categories';
+import { CATEGORY_OPTIONS } from '@/lib/constants/categories';
 
 export interface FilterOption {
   value: string;
@@ -106,10 +106,7 @@ export const itemsFilterConfig: EntityFilterConfig = {
       label: 'Kategorie',
       type: 'category',
       field: 'category',
-      options: Object.values(CATEGORY_LABELS).map((label) => ({
-        value: label,
-        label,
-      })),
+      options: CATEGORY_OPTIONS, // Uses German category names as stored in PocketBase
     },
   ],
 


### PR DESCRIPTION
Categories in PocketBase are stored with their German names (Haushalt, Küche, etc.), not English enum values. This commit updates the codebase to properly use German category names in all contexts:

- Updated category constants to define German values and provide CATEGORY_OPTIONS
- Modified item detail sheet to validate and use German category names in forms
- Updated filter configs to use German category names for filtering
- Enhanced getCategoryLabel to handle both English enums and German values

This ensures that category data is correctly saved to and read from the database.