### PR TITLE
Getting the basics started

### DIFF
--- a/app/(dashboard)/customers/page.tsx
+++ b/app/(dashboard)/customers/page.tsx
@@ -285,18 +285,18 @@ export default function CustomersPage() {
                       </th>
                     )}
                     {columnVisibility.isColumnVisible('active_reservations') && (
-                      <th className="px-4 py-2 text-left">
-                        <CalendarCheckIcon className="size-4" title="Aktive Reservierungen" />
+                      <th className="px-4 py-2 text-left" title="Aktive Reservierungen">
+                        <CalendarCheckIcon className="size-4" />
                       </th>
                     )}
                     {columnVisibility.isColumnVisible('active_rentals') && (
-                      <th className="px-4 py-2 text-left">
-                        <PackageIcon className="size-4" title="Aktive Ausleihen" />
+                      <th className="px-4 py-2 text-left" title="Aktive Ausleihen">
+                        <PackageIcon className="size-4" />
                       </th>
                     )}
                     {columnVisibility.isColumnVisible('total_rentals') && (
-                      <th className="px-4 py-2 text-left">
-                        <HistoryIcon className="size-4" title="Gesamt Ausleihen" />
+                      <th className="px-4 py-2 text-left" title="Gesamt Ausleihen">
+                        <HistoryIcon className="size-4" />
                       </th>
                     )}
                     {columnVisibility.isColumnVisible('street') && (

--- a/app/(dashboard)/items/page.tsx
+++ b/app/(dashboard)/items/page.tsx
@@ -382,8 +382,8 @@ export default function ItemsPage() {
                         </th>
                       )}
                       {columnVisibility.isColumnVisible('total_rentals') && (
-                        <th className="px-4 py-2 text-left">
-                          <HistoryIcon className="size-4" title="Gesamt Ausleihen" />
+                        <th className="px-4 py-2 text-left" title="Gesamt Ausleihen">
+                          <HistoryIcon className="size-4" />
                         </th>
                       )}
                       {columnVisibility.isColumnVisible('internal_note') && (

--- a/app/(dashboard)/rentals/page.tsx
+++ b/app/(dashboard)/rentals/page.tsx
@@ -300,8 +300,8 @@ export default function RentalsPage() {
                         </th>
                       )}
                       {columnVisibility.isColumnVisible('status') && (
-                        <th className="px-4 py-2 text-left">
-                          <BadgeCheckIcon className="size-4" title="Status" />
+                        <th className="px-4 py-2 text-left" title="Status">
+                          <BadgeCheckIcon className="size-4" />
                         </th>
                       )}
                       {columnVisibility.isColumnVisible('extended_on') && (


### PR DESCRIPTION
Move title attributes from Lucide icon components to their parent <th> elements to fix TypeScript compilation error on GitHub Pages build. The title prop is not in the Lucide icon type definitions, but is valid on HTML table header elements.

Fixed in:
- app/(dashboard)/customers/page.tsx (3 instances)
- app/(dashboard)/rentals/page.tsx (1 instance)
- app/(dashboard)/items/page.tsx (1 instance)