### PR TITLE
Add type parameters to getFirstListItem calls

### DIFF
--- a/components/detail-sheets/customer-detail-sheet.tsx
+++ b/components/detail-sheets/customer-detail-sheet.tsx
@@ -125,7 +125,7 @@ export function CustomerDetailSheet({
       // Fetch next available IID for new customers
       const fetchNextIid = async () => {
         try {
-          const lastCustomer = await collections.customers().getFirstListItem('', { sort: '-iid' });
+          const lastCustomer = await collections.customers().getFirstListItem<Customer>('', { sort: '-iid' });
           const nextIid = (lastCustomer?.iid || 0) + 1;
           form.reset({
             iid: nextIid,

--- a/components/detail-sheets/item-detail-sheet.tsx
+++ b/components/detail-sheets/item-detail-sheet.tsx
@@ -143,7 +143,7 @@ export function ItemDetailSheet({
       // Fetch next available IID for new items
       const fetchNextIid = async () => {
         try {
-          const lastItem = await collections.items().getFirstListItem('', { sort: '-iid' });
+          const lastItem = await collections.items().getFirstListItem<Item>('', { sort: '-iid' });
           const nextIid = (lastItem?.iid || 0) + 1;
           form.reset({
             iid: nextIid,


### PR DESCRIPTION
Add Customer and Item type parameters to getFirstListItem calls in detail sheets to fix TypeScript compilation errors.

Fixed in:
- components/detail-sheets/customer-detail-sheet.tsx
- components/detail-sheets/item-detail-sheet.tsx