### PR TITLE
Fix issues from ISSUES.MD file

### DIFF
--- a/ISSUES.MD
+++ b/ISSUES.MD
@@ -1,8 +1,3 @@
 KNOWN ISSUES TO FIX
 
-components/detail-sheets/rental-detail-sheet.tsx
-  - the system checks if items are set to available or reserved and then filters them in the item selection dialogue, or throws an error if the user tries to save and circumvent. this already works. however, returning that rental won't save because of this logic. 
-    possible solutions:
-      - skip the check on return
-      - make the return button force save the dialogue
-    
+No known issues at this time.

--- a/components/detail-sheets/rental-detail-sheet.tsx
+++ b/components/detail-sheets/rental-detail-sheet.tsx
@@ -485,17 +485,22 @@ export function RentalDetailSheet({
       );
 
       // Validate that all items are available (instock or reserved)
-      const unavailableItems = items.filter(item =>
-        item.status !== 'instock' && item.status !== 'reserved'
-      );
+      // Skip this check if we're returning a rental (returned_on is set)
+      const isReturning = !!data.returned_on;
 
-      if (unavailableItems.length > 0) {
-        const itemNames = unavailableItems.map(item =>
-          `${item.name} (#${String(item.iid).padStart(4, '0')})`
-        ).join(', ');
-        toast.error(`Folgende Gegenstände sind nicht verfügbar: ${itemNames}`);
-        setIsLoading(false);
-        return;
+      if (!isReturning) {
+        const unavailableItems = items.filter(item =>
+          item.status !== 'instock' && item.status !== 'reserved'
+        );
+
+        if (unavailableItems.length > 0) {
+          const itemNames = unavailableItems.map(item =>
+            `${item.name} (#${String(item.iid).padStart(4, '0')})`
+          ).join(', ');
+          toast.error(`Folgende Gegenstände sind nicht verfügbar: ${itemNames}`);
+          setIsLoading(false);
+          return;
+        }
       }
 
       const itemIds = items.map(item => item.id);


### PR DESCRIPTION
The system was preventing rentals from being returned because it validated that all items must be 'instock' or 'reserved'. However, when returning a rental, items are in 'outofstock' status (currently rented).

Solution: Skip the item availability validation when returning a rental (i.e., when returned_on is set). This allows the return process to complete successfully while still maintaining the validation for new rentals and updates that don't involve returning items.

Fixes issue described in ISSUES.MD