### PR TITLE
Add multi-copy item selection to rentals

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,192 @@
+# Feature Backlog
+
+This document tracks future enhancements and features that have been identified but not yet implemented.
+
+---
+
+## Partial Returns for Instanced Items
+
+**Priority:** Medium
+**Complexity:** High
+**Status:** Not Started
+
+### Description
+
+Allow customers to return only some copies of a multi-copy rental while keeping the rest. The system should split the rental into two separate records: one for returned copies and one for copies still rented.
+
+### Example Scenario
+
+1. Customer rents 3 copies of item #3414 (drill bits)
+2. After one week, customer returns 2 copies but keeps 1
+3. System creates:
+   - **Rental A** (original): 2 copies, marked as returned
+   - **Rental B** (new): 1 copy, still active with updated expected return date
+
+### Current Limitation
+
+The current implementation requires all copies in a rental to be returned together. There is no way to return a subset of copies.
+
+### Requirements
+
+#### User Interface
+- Add "Partial Return" button in rental detail sheet (next to "Return" button)
+- Show dialog allowing user to specify:
+  - How many copies are being returned
+  - How many copies are being kept
+  - New expected return date for remaining copies (optional)
+- Display clear confirmation message showing the split
+
+#### Data Handling
+- **Rental Split Logic:**
+  - Update original rental with returned copies count
+  - Create new rental for remaining copies with same customer and item
+  - Link rentals via new `parent_rental_id` field (requires DB schema change)
+  - Preserve all original rental metadata (employee, rented_on, etc.)
+
+- **Deposit Calculation:**
+  - Calculate proportional deposits: `deposit_per_copy = total_deposit / total_copies`
+  - Original rental: `deposit_returned_copies = deposit_per_copy × returned_copies`
+  - New rental: `deposit_remaining_copies = deposit_per_copy × remaining_copies`
+  - Handle edge cases where deposits don't divide evenly
+
+- **Instance Data:**
+  - Update instance data in both rental remarks
+  - Ensure copy counts are accurate in both records
+
+#### Backend Changes
+- Modify `updateItems()` in `rental.js` to handle partial returns
+- Add transaction support to ensure atomic rental splits
+- Update item availability calculations to account for split rentals
+
+#### Edge Cases to Handle
+1. **Lost/Damaged Copies:** Some returned copies are damaged
+   - Allow different `deposit_back` amounts for returned vs. remaining
+   - Add notes field to document condition
+
+2. **All Copies Lost:** Customer wants to report all copies lost without returning
+   - Mark rental as "lost" without creating split
+   - Adjust deposit_back accordingly
+
+3. **Multiple Partial Returns:** Customer returns in multiple batches
+   - Support chaining: Rental A → Rental B → Rental C
+   - Display rental history/lineage in UI
+
+4. **Concurrent Edits:** Staff tries to modify rental during split
+   - Implement optimistic locking or conflict resolution
+
+### Technical Considerations
+
+#### Database Schema Changes (Optional)
+While the current implementation works without schema changes, partial returns would benefit from:
+- `parent_rental_id` field to link split rentals
+- `split_from_rental_id` field to track the original rental
+- `is_partial_return` boolean flag
+
+Alternatively, track this information in the `remark` field using structured data.
+
+#### UI/UX Design
+
+**Partial Return Dialog:**
+```
+┌────────────────────────────────────────────────┐
+│ Teilrückgabe                                   │
+├────────────────────────────────────────────────┤
+│ Gegenstand: #3414 - Bohrbit Set               │
+│ Anzahl ausgeliehen: 3                         │
+│                                                │
+│ Anzahl zurückgeben: [2] (1-3)                 │
+│ Anzahl behalten:    1                          │
+│                                                │
+│ Neue Rückgabedatum: [DD.MM.YYYY] (Optional)   │
+│                                                │
+│ Kaution:                                       │
+│ - Pro Exemplar: €10.00                        │
+│ - Zurückgegeben: €20.00 (2×)                  │
+│ - Behalten: €10.00 (1×)                       │
+│                                                │
+│         [Abbrechen]  [Bestätigen]              │
+└────────────────────────────────────────────────┘
+```
+
+**Rental History View:**
+```
+Leihvorgang #42 (Original)
+├─ 3 Exemplare ausgeliehen am 01.01.2024
+├─ 2 Exemplare zurückgegeben am 08.01.2024 → Leihvorgang #43
+└─ Status: Teilweise zurückgegeben
+
+Leihvorgang #43 (Abgespalten von #42)
+├─ 1 Exemplar noch ausgeliehen
+└─ Erwartete Rückgabe: 15.01.2024
+```
+
+### Testing Checklist
+
+- [ ] Split rental with equal deposit distribution
+- [ ] Split rental with unequal deposits (e.g., damaged items)
+- [ ] Multiple sequential splits (A → B → C)
+- [ ] Return all remaining copies from split rental
+- [ ] Verify item availability updates correctly
+- [ ] Check rental history/lineage display
+- [ ] Validate deposit calculations are accurate
+- [ ] Test with single-copy items (should disable partial return)
+- [ ] Edge case: Try to return more copies than rented
+
+### Implementation Steps
+
+1. **Phase 1: UI & Validation**
+   - Add "Partial Return" button (conditional on copy count > 1)
+   - Create partial return dialog component
+   - Implement client-side validation
+
+2. **Phase 2: Data Layer**
+   - Modify rental create/update logic for splits
+   - Implement deposit calculation helpers
+   - Update instance data handling
+
+3. **Phase 3: Backend Integration**
+   - Extend `updateItems()` in rental.js
+   - Add transaction support for atomic splits
+   - Test with PocketBase hooks
+
+4. **Phase 4: History & Reporting**
+   - Display rental lineage in detail sheet
+   - Update CSV export to show split rentals
+   - Add filters for split/partial rentals
+
+5. **Phase 5: Testing & Documentation**
+   - Comprehensive testing of all scenarios
+   - Update user documentation
+   - Train staff on partial returns workflow
+
+### Related Issues
+
+- None yet
+
+### Notes
+
+- Consider whether partial returns should be restricted to certain item types
+- May want to add audit logging for rental splits
+- Could integrate with email notifications to customer about partial return
+- Discuss with team: should partial returns affect customer statistics?
+
+---
+
+## Future Ideas (Unplanned)
+
+### Item Reservation System Enhancements
+- Allow reserving specific copies (not just item types)
+- Notify customers when specific copy becomes available
+
+### Rental Extensions
+- Allow extending only some copies in a multi-copy rental
+- Implement automatic extension reminders
+
+### Batch Operations
+- Return multiple rentals at once
+- Rent multiple copies of different items in one transaction (already supported, but could improve UX)
+
+---
+
+**Last Updated:** 2024-11-11
+**Maintained By:** Development Team

--- a/app/(dashboard)/rentals/page.tsx
+++ b/app/(dashboard)/rentals/page.tsx
@@ -22,6 +22,7 @@ import { rentalsColumnConfig } from '@/lib/tables/column-configs';
 import type { RentalExpanded } from '@/types';
 import { formatDate, calculateRentalStatus } from '@/lib/utils/formatting';
 import { getRentalStatusLabel, RENTAL_STATUS_COLORS } from '@/lib/constants/statuses';
+import { parseInstanceData, getCopyCount } from '@/lib/utils/instance-data';
 
 export default function RentalsPage() {
   const searchParams = useSearchParams();
@@ -434,17 +435,28 @@ export default function RentalsPage() {
                           {columnVisibility.isColumnVisible('items') && (
                             <td className="px-4 py-3 text-sm">
                               {rental.expand?.items?.length > 0
-                                ? rental.expand.items.map((item) => (
-                                    <span key={item.id} className="inline-block mr-2">
-                                      <span className="font-mono mr-1">
-                                        <span className="inline-flex items-center justify-center bg-red-500 text-white font-bold px-1.5 py-0.5 rounded text-xs">
-                                          {String(item.iid).padStart(4, '0').substring(0, 2)}
+                                ? (() => {
+                                    const instanceData = parseInstanceData(rental.remark);
+                                    return rental.expand.items.map((item) => {
+                                      const copyCount = getCopyCount(instanceData, item.id);
+                                      return (
+                                        <span key={item.id} className="inline-block mr-2">
+                                          <span className="font-mono mr-1">
+                                            <span className="inline-flex items-center justify-center bg-red-500 text-white font-bold px-1.5 py-0.5 rounded text-xs">
+                                              {String(item.iid).padStart(4, '0').substring(0, 2)}
+                                            </span>
+                                            <span className="ml-0.5">{String(item.iid).padStart(4, '0').substring(2, 4)}</span>
+                                          </span>
+                                          {item.name}
+                                          {copyCount > 1 && (
+                                            <span className="ml-1 text-xs text-muted-foreground font-medium">
+                                              (×{copyCount})
+                                            </span>
+                                          )}
                                         </span>
-                                        <span className="ml-0.5">{String(item.iid).padStart(4, '0').substring(2, 4)}</span>
-                                      </span>
-                                      {item.name}
-                                    </span>
-                                  ))
+                                      );
+                                    });
+                                  })()
                                 : `${rental.items.length} Gegenstände`}
                             </td>
                           )}

--- a/lib/utils/instance-data.ts
+++ b/lib/utils/instance-data.ts
@@ -1,0 +1,116 @@
+/**
+ * Utilities for handling instanced items (items with multiple copies)
+ * Instance data is stored in the rental remark field using format:
+ * [INSTANCE_DATA:{"item_id_1":2,"item_id_2":3}]User's regular notes...
+ */
+
+/**
+ * Map of item IDs to their copy counts in a rental
+ */
+export type InstanceData = Record<string, number>;
+
+/**
+ * Parse instance data from a rental remark field
+ * @param remark - The remark field from a rental record
+ * @returns Object mapping item IDs to copy counts, empty object if not found
+ */
+export function parseInstanceData(remark: string | undefined): InstanceData {
+  if (!remark || typeof remark !== 'string') {
+    return {};
+  }
+
+  const match = remark.match(/^\[INSTANCE_DATA:(\{[^}]+\})\]/);
+  if (!match) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(match[1]) as InstanceData;
+  } catch (e) {
+    console.warn('Failed to parse instance data from remark:', e);
+    return {};
+  }
+}
+
+/**
+ * Serialize instance data and combine with user notes
+ * @param instanceData - Map of item IDs to copy counts
+ * @param userNotes - User's regular notes (without instance data)
+ * @returns Combined string with instance data prepended
+ */
+export function serializeInstanceData(
+  instanceData: InstanceData,
+  userNotes: string = ''
+): string {
+  // If no instance data or all values are 1, don't add the marker
+  const hasMultipleCopies = Object.values(instanceData).some(count => count > 1);
+  if (!hasMultipleCopies) {
+    return userNotes;
+  }
+
+  const json = JSON.stringify(instanceData);
+  const marker = `[INSTANCE_DATA:${json}]`;
+
+  return userNotes ? `${marker}${userNotes}` : marker;
+}
+
+/**
+ * Extract user notes from a remark field (removing instance data)
+ * @param remark - The remark field from a rental record
+ * @returns User's notes without the instance data marker
+ */
+export function extractUserNotes(remark: string | undefined): string {
+  if (!remark || typeof remark !== 'string') {
+    return '';
+  }
+
+  const match = remark.match(/^\[INSTANCE_DATA:\{[^}]+\}\]/);
+  if (!match) {
+    return remark;
+  }
+
+  return remark.substring(match[0].length);
+}
+
+/**
+ * Get the copy count for a specific item from instance data
+ * @param instanceData - Map of item IDs to copy counts
+ * @param itemId - The item ID to look up
+ * @returns Copy count (defaults to 1 if not found)
+ */
+export function getCopyCount(instanceData: InstanceData, itemId: string): number {
+  return instanceData[itemId] || 1;
+}
+
+/**
+ * Set the copy count for a specific item in instance data
+ * @param instanceData - Map of item IDs to copy counts
+ * @param itemId - The item ID to update
+ * @param count - The copy count to set
+ * @returns New instance data object with updated count
+ */
+export function setCopyCount(
+  instanceData: InstanceData,
+  itemId: string,
+  count: number
+): InstanceData {
+  return {
+    ...instanceData,
+    [itemId]: count,
+  };
+}
+
+/**
+ * Remove an item from instance data
+ * @param instanceData - Map of item IDs to copy counts
+ * @param itemId - The item ID to remove
+ * @returns New instance data object without the specified item
+ */
+export function removeCopyCount(
+  instanceData: InstanceData,
+  itemId: string
+): InstanceData {
+  const newData = { ...instanceData };
+  delete newData[itemId];
+  return newData;
+}


### PR DESCRIPTION
This feature allows tracking and renting multiple copies of the same item through a rental system. Items with multiple copies can now have specific quantities selected when creating rentals, with automatic availability tracking and deposit calculations.

## Backend Changes (manual deployment required)
- Modified !database-settings/pb_hooks/services/rental.js
  - Added parseInstanceData() to extract copy counts from rental remarks
  - Updated updateItems() to track copy availability across rentals
  - Items only marked 'outofstock' when ALL copies are rented
  - Updated exportCsv() to show copy counts in exports
  - Updated sendReminderMail() to include copy data

## Frontend Changes
- New utility: lib/utils/instance-data.ts
  - Parse/serialize instance data in rental remark field
  - Format: [INSTANCE_DATA:{"item_id":count}]User notes...
  - Helper functions for managing copy counts

- New utility: lib/utils/item-availability.ts
  - Calculate available copies across active rentals
  - Validate rental requests against availability
  - Efficient batch availability checking

- Updated components/detail-sheets/rental-detail-sheet.tsx
  - Added copy count selectors (+ / -) for items with multiple copies
  - Real-time availability checking and validation
  - Deposit calculation accounts for copy counts
  - Instance data automatically serialized into remark field
  - User notes separated from instance data in UI

- Updated app/(dashboard)/rentals/page.tsx
  - Display copy counts in rental tables: "3414 (×2)"
  - Parse instance data from rental remarks

## Documentation
- Added BACKLOG.md tracking future partial returns feature

## Key Features
- Backwards compatible: existing rentals default to 1 copy
- Items with 1 copy show no copy selector (unchanged UX)
- Deposit calculation: deposit × copy_count
- Real-time availability: shows "X of Y available"
- Validation prevents over-renting copies
- Copy counts visible in rental lists and tables

## Testing Notes
- Type checking passes (aside from missing node_modules)
- Requires manual deployment of backend hooks
- Test with items having copies > 1