### PR TITLE
Refactor instanced items to use requested_copies JSON field

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,6 +4,13 @@ This document tracks future enhancements and features that have been identified 
 
 ---
 
+## Implementation Note
+
+**Instanced Items Feature** is now live using the `requested_copies` JSON field in the rental collection.
+Copy counts are stored as: `{"item_id": count}` and automatically tracked for availability.
+
+---
+
 ## Partial Returns for Instanced Items
 
 **Priority:** Medium
@@ -49,8 +56,8 @@ The current implementation requires all copies in a rental to be returned togeth
   - New rental: `deposit_remaining_copies = deposit_per_copy × remaining_copies`
   - Handle edge cases where deposits don't divide evenly
 
-- **Instance Data:**
-  - Update instance data in both rental remarks
+- **Copy Count Data:**
+  - Update `requested_copies` JSON field in both rental records
   - Ensure copy counts are accurate in both records
 
 #### Backend Changes
@@ -82,7 +89,7 @@ While the current implementation works without schema changes, partial returns w
 - `split_from_rental_id` field to track the original rental
 - `is_partial_return` boolean flag
 
-Alternatively, track this information in the `remark` field using structured data.
+Note: Copy counts are already tracked in the `requested_copies` JSON field.
 
 #### UI/UX Design
 

--- a/app/(dashboard)/rentals/page.tsx
+++ b/app/(dashboard)/rentals/page.tsx
@@ -22,7 +22,7 @@ import { rentalsColumnConfig } from '@/lib/tables/column-configs';
 import type { RentalExpanded } from '@/types';
 import { formatDate, calculateRentalStatus } from '@/lib/utils/formatting';
 import { getRentalStatusLabel, RENTAL_STATUS_COLORS } from '@/lib/constants/statuses';
-import { parseInstanceData, getCopyCount } from '@/lib/utils/instance-data';
+import { getCopyCount } from '@/lib/utils/instance-data';
 
 export default function RentalsPage() {
   const searchParams = useSearchParams();
@@ -435,28 +435,25 @@ export default function RentalsPage() {
                           {columnVisibility.isColumnVisible('items') && (
                             <td className="px-4 py-3 text-sm">
                               {rental.expand?.items?.length > 0
-                                ? (() => {
-                                    const instanceData = parseInstanceData(rental.remark);
-                                    return rental.expand.items.map((item) => {
-                                      const copyCount = getCopyCount(instanceData, item.id);
-                                      return (
-                                        <span key={item.id} className="inline-block mr-2">
-                                          <span className="font-mono mr-1">
-                                            <span className="inline-flex items-center justify-center bg-red-500 text-white font-bold px-1.5 py-0.5 rounded text-xs">
-                                              {String(item.iid).padStart(4, '0').substring(0, 2)}
-                                            </span>
-                                            <span className="ml-0.5">{String(item.iid).padStart(4, '0').substring(2, 4)}</span>
+                                ? rental.expand.items.map((item) => {
+                                    const copyCount = getCopyCount(rental.requested_copies, item.id);
+                                    return (
+                                      <span key={item.id} className="inline-block mr-2">
+                                        <span className="font-mono mr-1">
+                                          <span className="inline-flex items-center justify-center bg-red-500 text-white font-bold px-1.5 py-0.5 rounded text-xs">
+                                            {String(item.iid).padStart(4, '0').substring(0, 2)}
                                           </span>
-                                          {item.name}
-                                          {copyCount > 1 && (
-                                            <span className="ml-1 text-xs text-muted-foreground font-medium">
-                                              (×{copyCount})
-                                            </span>
-                                          )}
+                                          <span className="ml-0.5">{String(item.iid).padStart(4, '0').substring(2, 4)}</span>
                                         </span>
-                                      );
-                                    });
-                                  })()
+                                        {item.name}
+                                        {copyCount > 1 && (
+                                          <span className="ml-1 text-xs text-muted-foreground font-medium">
+                                            (×{copyCount})
+                                          </span>
+                                        )}
+                                      </span>
+                                    );
+                                  })
                                 : `${rental.items.length} Gegenstände`}
                             </td>
                           )}

--- a/components/detail-sheets/rental-detail-sheet.tsx
+++ b/components/detail-sheets/rental-detail-sheet.tsx
@@ -51,7 +51,7 @@ import { formatDate, formatCurrency, calculateRentalStatus, dateToLocalString, l
 import { cn } from '@/lib/utils';
 import { useIdentity } from '@/hooks/use-identity';
 import type { Rental, RentalExpanded, Customer, Item } from '@/types';
-import { parseInstanceData, serializeInstanceData, extractUserNotes, getCopyCount, setCopyCount, removeCopyCount, type InstanceData } from '@/lib/utils/instance-data';
+import { getCopyCount, setCopyCount, removeCopyCount, type InstanceData } from '@/lib/utils/instance-data';
 import { getMultipleItemAvailability, type ItemAvailability } from '@/lib/utils/item-availability';
 
 // Validation schema
@@ -186,9 +186,8 @@ export function RentalDetailSheet({
         setSelectedItems(rental.expand.items);
         setValue('item_iids', rental.expand.items.map(item => item.iid));
 
-        // Parse instance data from remark
-        const parsedInstanceData = parseInstanceData(rental.remark);
-        setInstanceData(parsedInstanceData);
+        // Load instance data from requested_copies field
+        setInstanceData(rental.requested_copies || {});
       }
 
       // Set form values - handle both 'T' and space separators in date strings
@@ -212,7 +211,7 @@ export function RentalDetailSheet({
         returned_on: returnedOnValue,
         expected_on: expectedOnValue,
         extended_on: extendedOnValue,
-        remark: extractUserNotes(rental.remark), // Extract only user notes, hide instance data
+        remark: rental.remark || '', // User notes are now separate from instance data
         employee: rental.employee || '',
         employee_back: rental.employee_back || '',
       });
@@ -593,19 +592,17 @@ export function RentalDetailSheet({
 
       const itemIds = items.map(item => item.id);
 
-      // Serialize instance data into remark field
-      const remarkWithInstanceData = serializeInstanceData(instanceData, data.remark || '');
-
       const formData: Partial<Rental> = {
         customer: customer.id,
         items: itemIds, // Multiple items per rental
+        requested_copies: instanceData, // Store copy counts in JSON field
         deposit: data.deposit,
         deposit_back: data.deposit_back,
         rented_on: data.rented_on,
         returned_on: data.returned_on || undefined,
         expected_on: data.expected_on,
         extended_on: data.extended_on || undefined,
-        remark: remarkWithInstanceData || undefined,
+        remark: data.remark || undefined, // User notes, no instance data
         employee: data.employee,
         employee_back: data.employee_back || undefined,
       };

--- a/lib/utils/instance-data.ts
+++ b/lib/utils/instance-data.ts
@@ -1,7 +1,6 @@
 /**
  * Utilities for handling instanced items (items with multiple copies)
- * Instance data is stored in the rental remark field using format:
- * [INSTANCE_DATA:{"item_id_1":2,"item_id_2":3}]User's regular notes...
+ * Instance data is stored in the rental requested_copies JSON field
  */
 
 /**
@@ -10,107 +9,47 @@
 export type InstanceData = Record<string, number>;
 
 /**
- * Parse instance data from a rental remark field
- * @param remark - The remark field from a rental record
- * @returns Object mapping item IDs to copy counts, empty object if not found
- */
-export function parseInstanceData(remark: string | undefined): InstanceData {
-  if (!remark || typeof remark !== 'string') {
-    return {};
-  }
-
-  const match = remark.match(/^\[INSTANCE_DATA:(\{[^}]+\})\]/);
-  if (!match) {
-    return {};
-  }
-
-  try {
-    return JSON.parse(match[1]) as InstanceData;
-  } catch (e) {
-    console.warn('Failed to parse instance data from remark:', e);
-    return {};
-  }
-}
-
-/**
- * Serialize instance data and combine with user notes
- * @param instanceData - Map of item IDs to copy counts
- * @param userNotes - User's regular notes (without instance data)
- * @returns Combined string with instance data prepended
- */
-export function serializeInstanceData(
-  instanceData: InstanceData,
-  userNotes: string = ''
-): string {
-  // If no instance data or all values are 1, don't add the marker
-  const hasMultipleCopies = Object.values(instanceData).some(count => count > 1);
-  if (!hasMultipleCopies) {
-    return userNotes;
-  }
-
-  const json = JSON.stringify(instanceData);
-  const marker = `[INSTANCE_DATA:${json}]`;
-
-  return userNotes ? `${marker}${userNotes}` : marker;
-}
-
-/**
- * Extract user notes from a remark field (removing instance data)
- * @param remark - The remark field from a rental record
- * @returns User's notes without the instance data marker
- */
-export function extractUserNotes(remark: string | undefined): string {
-  if (!remark || typeof remark !== 'string') {
-    return '';
-  }
-
-  const match = remark.match(/^\[INSTANCE_DATA:\{[^}]+\}\]/);
-  if (!match) {
-    return remark;
-  }
-
-  return remark.substring(match[0].length);
-}
-
-/**
- * Get the copy count for a specific item from instance data
- * @param instanceData - Map of item IDs to copy counts
+ * Get the copy count for a specific item from requested_copies
+ * @param requestedCopies - The requested_copies object from a rental record
  * @param itemId - The item ID to look up
  * @returns Copy count (defaults to 1 if not found)
  */
-export function getCopyCount(instanceData: InstanceData, itemId: string): number {
-  return instanceData[itemId] || 1;
+export function getCopyCount(
+  requestedCopies: InstanceData | undefined,
+  itemId: string
+): number {
+  return requestedCopies?.[itemId] || 1;
 }
 
 /**
- * Set the copy count for a specific item in instance data
- * @param instanceData - Map of item IDs to copy counts
+ * Set the copy count for a specific item in requested_copies
+ * @param requestedCopies - The requested_copies object from a rental record
  * @param itemId - The item ID to update
  * @param count - The copy count to set
- * @returns New instance data object with updated count
+ * @returns New requested_copies object with updated count
  */
 export function setCopyCount(
-  instanceData: InstanceData,
+  requestedCopies: InstanceData | undefined,
   itemId: string,
   count: number
 ): InstanceData {
   return {
-    ...instanceData,
+    ...(requestedCopies || {}),
     [itemId]: count,
   };
 }
 
 /**
- * Remove an item from instance data
- * @param instanceData - Map of item IDs to copy counts
+ * Remove an item from requested_copies
+ * @param requestedCopies - The requested_copies object from a rental record
  * @param itemId - The item ID to remove
- * @returns New instance data object without the specified item
+ * @returns New requested_copies object without the specified item
  */
 export function removeCopyCount(
-  instanceData: InstanceData,
+  requestedCopies: InstanceData | undefined,
   itemId: string
 ): InstanceData {
-  const newData = { ...instanceData };
+  const newData = { ...(requestedCopies || {}) };
   delete newData[itemId];
   return newData;
 }

--- a/lib/utils/item-availability.ts
+++ b/lib/utils/item-availability.ts
@@ -4,7 +4,7 @@
 
 import { collections } from '@/lib/pocketbase/client';
 import type { Item, RentalExpanded } from '@/types';
-import { parseInstanceData, getCopyCount } from './instance-data';
+import { getCopyCount } from './instance-data';
 
 /**
  * Result of availability check for an item
@@ -49,8 +49,7 @@ export async function getItemAvailability(
         continue;
       }
 
-      const instanceData = parseInstanceData(rental.remark);
-      rentedCopies += getCopyCount(instanceData, itemId);
+      rentedCopies += getCopyCount(rental.requested_copies, itemId);
     }
 
     const availableCopies = Math.max(0, totalCopies - rentedCopies);
@@ -120,12 +119,10 @@ export async function getMultipleItemAvailability(
         continue;
       }
 
-      const instanceData = parseInstanceData(rental.remark);
-
       for (const itemId of itemIds) {
         if (rental.items.includes(itemId)) {
           const currentCount = rentedCopiesMap.get(itemId) || 0;
-          rentedCopiesMap.set(itemId, currentCount + getCopyCount(instanceData, itemId));
+          rentedCopiesMap.set(itemId, currentCount + getCopyCount(rental.requested_copies, itemId));
         }
       }
     }

--- a/types/index.ts
+++ b/types/index.ts
@@ -300,6 +300,9 @@ export interface Rental extends BaseRecord {
   /** Item ID references (multiple items per rental) */
   items: string[];
 
+  /** Number of copies requested for each item (JSON object: {item_id: count}) */
+  requested_copies?: Record<string, number>;
+
   /** Deposit amount given */
   deposit: number;
 


### PR DESCRIPTION
Major refactoring to use the new requested_copies JSON field instead of storing copy count data in the remark field. This provides cleaner data separation and proper typing.

## Key Changes

### Frontend
- **types/index.ts**: Added requested_copies field to Rental interface
- **lib/utils/instance-data.ts**: Simplified to only helper functions
  - Removed: parseInstanceData(), serializeInstanceData(), extractUserNotes()
  - Kept: getCopyCount(), setCopyCount(), removeCopyCount()
- **lib/utils/item-availability.ts**: Read from requested_copies instead of remark
- **components/detail-sheets/rental-detail-sheet.tsx**:
  - Load instance data from rental.requested_copies
  - Save requested_copies as separate JSON field
  - User notes in remark field remain clean and editable
- **app/(dashboard)/rentals/page.tsx**: Display copy counts from requested_copies

### Backend
- **!database-settings/pb_hooks/services/rental.js**:
  - Updated updateItems() to read from requested_copies field
  - Copy-aware status updates: item only goes to 'outofstock' when ALL copies rented
  - Updated exportCsv() to show copy counts from requested_copies
  - Updated sendReminderMail() to include copy counts

### Documentation
- **BACKLOG.md**: Updated to reflect requested_copies usage

## Benefits
- ✅ Clean separation: notes in remark, copy counts in requested_copies
- ✅ Proper data typing (JSON instead of string parsing)
- ✅ Easier to query and validate
- ✅ No risk of users accidentally modifying copy data
- ✅ Backwards compatible: missing requested_copies defaults to 1 copy

## Testing Notes
- Requires PocketBase with requested_copies field (JSON type) in rental collection
- Backend hooks require manual deployment to PocketBase server (Currently implemented on instanced-objects-changes branch)
- Existing rentals without requested_copies will default to 1 copy per item