### PR TITLE
Fix TypeScript type error in SortableHeader component

### DIFF
--- a/components/table/sortable-header.tsx
+++ b/components/table/sortable-header.tsx
@@ -11,7 +11,7 @@ export type SortDirection = 'asc' | 'desc' | null;
 
 export interface SortableHeaderProps {
   /** Column label to display */
-  label: string;
+  label: React.ReactNode;
 
   /** Current sort direction for this column */
   sortDirection: SortDirection;


### PR DESCRIPTION
Changed label prop type from string to React.ReactNode to support both text labels and icon elements, fixing compilation error in customers page where MailIcon is used as a sortable header label.