### PR TITLE
Fix date filters to work with datetime fields

### DIFF
--- a/lib/filters/filter-utils.ts
+++ b/lib/filters/filter-utils.ts
@@ -93,8 +93,10 @@ export function buildPocketBaseFilter(
         case 'date':
           if (Array.isArray(filter.value)) {
             const [start, end] = filter.value;
+            // Append time suffixes to ensure datetime fields are correctly filtered
+            // Start of day: 00:00:00, End of day: 23:59:59
             fieldParts.push(
-              `(${filter.field} >= '${start}' && ${filter.field} <= '${end}')`
+              `(${filter.field} >= '${start} 00:00:00' && ${filter.field} <= '${end} 23:59:59')`
             );
           }
           break;
@@ -176,9 +178,9 @@ export function buildPocketBaseFilter(
       case 'date':
         if (Array.isArray(filter.value)) {
           const [start, end] = filter.value;
-          // Items OUTSIDE this date range
+          // Items OUTSIDE this date range (with time suffixes for datetime fields)
           filterParts.push(
-            `(${filter.field} < '${start}' || ${filter.field} > '${end}')`
+            `(${filter.field} < '${start} 00:00:00' || ${filter.field} > '${end} 23:59:59')`
           );
         }
         break;


### PR DESCRIPTION
Date filters were not working because the comparison used date-only
strings (e.g., '2024-01-08') against datetime values stored in PocketBase
(e.g., '2024-01-08 10:30:00.000Z'). String comparison failed because
datetime strings are lexicographically greater than date-only strings.

Added time suffixes to date comparisons:
- Start of range: append ' 00:00:00'
- End of range: append ' 23:59:59'

This ensures all times within the selected day(s) are included in the
filter results.