### PR TITLE
fix: convert-to-rental basePath on dashboard

### DIFF
--- a/components/dashboard/todays-reservations-section.tsx
+++ b/components/dashboard/todays-reservations-section.tsx
@@ -4,6 +4,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -28,6 +29,7 @@ interface TodaysReservationsSectionProps {
 export function TodaysReservationsSection({
   onReservationCompleted,
 }: TodaysReservationsSectionProps) {
+  const router = useRouter();
   const [reservations, setReservations] = useState<ReservationExpanded[]>([]);
   const [loading, setLoading] = useState(true);
   const [completingId, setCompletingId] = useState<string | null>(null);
@@ -145,7 +147,7 @@ export function TodaysReservationsSection({
       params.set("item_ids", itemIids);
     }
 
-    window.location.href = `/rentals?${params.toString()}`;
+    router.push(`/rentals?${params.toString()}`);
   }
 
   async function handleMarkAsDone(reservationId: string) {


### PR DESCRIPTION
## Bug

When the app is deployed under a sub-path (e.g. GitHub Pages with a `basePath` configured in `next.config.ts`), clicking "Complete reservation" on the dashboard redirected to an incorrect absolute URL — the `basePath` prefix was silently dropped.

**Root cause:** `window.location.href = '/rentals?...'` bypasses Next.js entirely and constructs the URL relative to the origin, ignoring `basePath`.

## Fix

Replace `window.location.href` with `router.push()` from `next/navigation`. Next.js's App Router automatically prepends the configured `basePath` for paths starting with `/`, so the redirect now works correctly in all deployment configurations.

Changed file: `components/dashboard/todays-reservations-section.tsx`

A scan of `components/dashboard/` and `components/bookings/` found no other occurrences of this pattern.

Fixes #56
Related to leih-lokal/llka-deploy#1