### PR TITLE
fix: pickup date picker timezone drift

### DIFF
--- a/components/detail-sheets/reservation-detail-sheet.tsx
+++ b/components/detail-sheets/reservation-detail-sheet.tsx
@@ -64,6 +64,12 @@ import { FormHelpPanel } from "./form-help-panel";
 import { DOCUMENTATION } from "@/lib/constants/documentation";
 import { useHelpCollapsed } from "@/hooks/use-help-collapsed";
 import { FormattedId } from "@/components/ui/formatted-id";
+import { format, parse } from "date-fns";
+
+// Local-time helpers for datetime-local inputs — keep UTC conversion at DB boundaries only
+const toLocalInput = (d: Date) => format(d, "yyyy-MM-dd'T'HH:mm");
+const fromLocalInput = (s: string) =>
+  parse(s, "yyyy-MM-dd'T'HH:mm", new Date());
 
 // Validation schema
 const reservationSchema = z.object({
@@ -141,7 +147,7 @@ export function ReservationDetailSheet({
       customer_email: "",
       is_new_customer: false,
       item_ids: [],
-      pickup: new Date().toISOString().slice(0, 16), // YYYY-MM-DDTHH:MM
+      pickup: toLocalInput(new Date()), // YYYY-MM-DDTHH:mm (local time)
       comments: "",
       done: false,
       on_premises: false,
@@ -303,7 +309,7 @@ export function ReservationDetailSheet({
           customer_email: reservation.customer_email || "",
           is_new_customer: reservation.is_new_customer,
           item_ids: reservation.items,
-          pickup: reservation.pickup.slice(0, 16), // Convert to datetime-local format
+          pickup: toLocalInput(new Date(reservation.pickup)), // UTC ISO → local datetime-local
           comments: reservation.comments || "",
           done: reservation.done,
           on_premises: reservation.on_premises,
@@ -320,7 +326,7 @@ export function ReservationDetailSheet({
           customer_email: "",
           is_new_customer: false,
           item_ids: [],
-          pickup: new Date().toISOString().slice(0, 16),
+          pickup: toLocalInput(new Date()),
           comments: "",
           done: false,
           on_premises: false,
@@ -359,8 +365,8 @@ export function ReservationDetailSheet({
         return;
       }
 
-      // Convert datetime-local format (YYYY-MM-DDTHH:MM) to ISO 8601 with seconds
-      const pickupDate = new Date(data.pickup);
+      // Convert datetime-local (local time) → UTC ISO 8601 for DB storage
+      const pickupDate = fromLocalInput(data.pickup);
       const pickupISO = pickupDate.toISOString();
 
       const formData: Partial<Reservation> = {
@@ -993,7 +999,7 @@ export function ReservationDetailSheet({
                                   const currentTime = currentPickup
                                     ? currentPickup.slice(11, 16)
                                     : "10:00";
-                                  const newDate = `${date.toISOString().slice(0, 10)}T${currentTime}`;
+                                  const newDate = `${format(date, 'yyyy-MM-dd')}T${currentTime}`;
                                   setValue("pickup", newDate, {
                                     shouldDirty: true,
                                   });
@@ -1016,7 +1022,7 @@ export function ReservationDetailSheet({
                           const currentPickup = form.watch("pickup");
                           const currentDate = currentPickup
                             ? currentPickup.slice(0, 10)
-                            : new Date().toISOString().slice(0, 10);
+                            : format(new Date(), 'yyyy-MM-dd');
                           const newPickup = `${currentDate}T${e.target.value}`;
                           setValue("pickup", newPickup, { shouldDirty: true });
                         }}


### PR DESCRIPTION
## Summary

Fixes #57 — the pickup date/time picker in the reservation detail sheet mixed UTC (`toISOString()`) with `datetime-local` (local time) at several sites, causing the stored pickup time to shift by the user's UTC offset on every open-then-save cycle.

## Four drift points fixed (all in `components/detail-sheets/reservation-detail-sheet.tsx`)

1. **Default value — `useForm` defaultValues** (line 147): `new Date().toISOString().slice(0, 16)` produced a UTC datetime string, so the default shown to users in non-UTC timezones was wrong. Fixed to `toLocalInput(new Date())` (uses `date-fns format`).

2. **Reading an existing reservation into the form** (line 309): `reservation.pickup.slice(0, 16)` sliced a UTC ISO string from PocketBase and passed it directly to the `datetime-local` input, treating UTC bytes as local time. Fixed to `toLocalInput(new Date(reservation.pickup))` — `new Date()` correctly parses the UTC ISO string, then `format` emits local time.

3. **Writing back on submit** (line 365): `new Date(data.pickup)` is actually fine in isolation (browsers parse bare `YYYY-MM-DDTHH:mm` as local time), but was fragile and combined with bug 2 it created one-way drift. Replaced with explicit `fromLocalInput(data.pickup)` (`date-fns parse` with an explicit local-time format string) so the intent is unambiguous.

4. **Calendar `onSelect` callback** (line 999): `date.toISOString().slice(0, 10)` extracted the UTC date from a calendar-selected local-midnight Date, giving the *previous* day for any positive-UTC-offset timezone before midnight UTC. Fixed to `format(date, 'yyyy-MM-dd')` which uses local time.

**Bonus (line 1022):** The time input's `onChange` fallback also used `toISOString().slice(0, 10)` for the current date — fixed to `format(new Date(), 'yyyy-MM-dd')` for consistency.

## Approach

Single convention: **the form `pickup` field is always a local-time `datetime-local` string (`YYYY-MM-DDTHH:mm`)**. UTC conversion only happens at DB boundaries (read: `new Date(isoString)` → `toLocalInput`; write: `fromLocalInput` → `.toISOString()`). Two inline helpers (`toLocalInput` / `fromLocalInput`) using `date-fns` `format`/`parse` make the intent explicit. No new dependencies — `date-fns` was already in `package.json`.

## Also affected (follow-up needed, not in this PR)

A quick search suggests the same `toISOString().slice(0, 16)` / `.slice(0, 16)` on UTC strings anti-pattern may be present in:
- `components/detail-sheets/booking-detail-sheet.tsx`
- `components/detail-sheets/rental-detail-sheet.tsx`

These were **not touched** in this PR per scope constraints. A follow-up issue/PR should address them with the same pattern.