### PR TITLE
fix: item form parts/msrp resolver type error

### DIFF
--- a/components/detail-sheets/item-detail-sheet.tsx
+++ b/components/detail-sheets/item-detail-sheet.tsx
@@ -60,19 +60,13 @@ const itemSchema = z.object({
   synonyms: z.string().optional(), // Comma-separated
   packaging: z.string().optional(),
   manual: z.string().optional(),
-  parts: z.preprocess(
-    v => v === '' || v == null || Number.isNaN(v) ? undefined : v,
-    z.number().int().min(0, 'Teile muss positiv sein').optional()
-  ),
+  parts: z.number().int().min(0, 'Teile muss positiv sein').optional(),
   copies: z.number().int().min(1, 'Anzahl muss mindestens 1 sein'),
   status: z.enum(['instock', 'outofstock', 'reserved', 'onbackorder', 'lost', 'repairing', 'forsale', 'deleted']),
   highlight_color: z.enum(['red', 'orange', 'yellow', 'green', 'teal', 'blue', 'purple', 'pink', '']).optional(),
   internal_note: z.string().optional(),
   added_on: z.string(),
-  msrp: z.preprocess(
-    v => v === '' || v == null || Number.isNaN(v) ? undefined : v,
-    z.number().min(0, 'UVP muss positiv sein').optional()
-  ),
+  msrp: z.number().min(0, 'UVP muss positiv sein').optional(),
   is_protected: z.boolean().optional(),
 });
 
@@ -645,7 +639,10 @@ export function ItemDetailSheet({
                         id="msrp"
                         type="number"
                         step="0.01"
-                        {...form.register('msrp', { valueAsNumber: true })}
+                        {...form.register('msrp', {
+                          setValueAs: (v) =>
+                            v === '' || v == null ? undefined : Number(v),
+                        })}
                         className="mt-1"
                       />
                       {form.formState.errors.msrp && (
@@ -677,7 +674,10 @@ export function ItemDetailSheet({
                       <Input
                         id="parts"
                         type="number"
-                        {...form.register('parts', { valueAsNumber: true })}
+                        {...form.register('parts', {
+                          setValueAs: (v) =>
+                            v === '' || v == null ? undefined : Number(v),
+                        })}
                         className="mt-1"
                       />
                       {form.formState.errors.parts && (


### PR DESCRIPTION
## Hotfix for #62

The Zod \`preprocess\` wrappers added in #62 made the input type for \`parts\` and \`msrp\` \`unknown\` (required), while \`useForm<ItemFormValues>\` infers them as optional from the output type. This produced a Resolver type mismatch and broke \`next build\`:

\`\`\`
Type 'Resolver<{ ...; parts: unknown; ...; }, ...>' is not assignable to
type 'Resolver<{ ...; parts?: number | undefined; ...; }, ...>'.
  Property 'parts' is optional in type ... but required in type ...
\`\`\`

## Fix

Move the empty/NaN → \`undefined\` coercion out of the schema and into the \`register()\` call via \`setValueAs\`. The schema reverts to plain \`z.number().optional()\`, input/output types stay aligned, and the DOM-clearing behavior from #58/#59 is preserved because \`setValueAs\` runs on every keystroke and on \`form.reset\`.

\`\`\`tsx
{...form.register('parts', {
  setValueAs: (v) =>
    v === '' || v == null ? undefined : Number(v),
})}
\`\`\`

Verified locally with \`npx tsc --noEmit\` (clean).